### PR TITLE
Add note about potential whitespace issues in Angular v6, and possible solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,11 @@ export class HomeModule { }
 You can use `markdown` component to either parse static markdown directly from your html markup, load the content from a remote url using `src` property or bind a variable to your component using `data` property. You can get a hook on loading error using `error` output event property.
 
 ```html
-<!-- static markdown -->
-<markdown>
+<!-- static markdown in templates -->
+<!-- Note: as of Angular v6, the template compiler strips whitespace by default.
+     Use the ngPreserveWhitespaces directive to preserve whitespace such as newlines
+     in order for the Markdown-formatted content to render as intended. -->
+<markdown ngPreserveWhitespaces>
   # Markdown
 </markdown>
 


### PR DESCRIPTION
Hi @jfcere, I ran into this when upgrading my app to Angular v6, and I thought I would send a PR documenting the solution I used, in case it's helpful. If whitespace (including newlines) are stripped out from the template, it causes issues in the rendered Markdown (in my case, it put almost everything into the the content's first heading, due to the newlines being removed.)

I also wonder if the markdown directive could be updated to also take care of telling the Angular template compiler to preserve whitespace, but I haven't looked into it yet.
