### PR TITLE
Return empty string when value is null/undefined using MarkdownPipe

### DIFF
--- a/lib/src/markdown.pipe.spec.ts
+++ b/lib/src/markdown.pipe.spec.ts
@@ -28,9 +28,19 @@ describe('MarkdownPipe', () => {
     pipe = new MarkdownPipe(elementRef, markdownService, zone);
   });
 
+  it('should return empty string when value is null/undefined', () => {
+
+    const markdowns: any[] = [undefined, null];
+
+    markdowns.forEach(markdown => {
+      const result = pipe.transform(markdown);
+      expect(result).toBe('');
+    });
+  });
+
   it('should log error and return value when parameter is not a string', () => {
 
-    const markdowns: any[] = [undefined, null, 0, {}, [], /regex/];
+    const markdowns: any[] = [0, {}, [], /regex/];
 
     spyOn(console, 'error');
 

--- a/lib/src/markdown.pipe.ts
+++ b/lib/src/markdown.pipe.ts
@@ -15,6 +15,10 @@ export class MarkdownPipe implements PipeTransform {
   ) { }
 
   transform(value: string): string {
+    if (value == null) {
+      return '';
+    }
+
     if (typeof value !== 'string') {
       console.error(`MarkdownPipe has been invoked with an invalid value type [${value}]`);
       return value;


### PR DESCRIPTION
Fix #132 