### PR TITLE
Fix #170 querySelectorAll#forEach does not exist on IE11

### DIFF
--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -67,9 +67,8 @@ export class MarkdownService {
       if (!element) {
         element = document;
       }
-      element
-        .querySelectorAll('pre code:not([class*="language-"])')
-        .forEach(x => x.classList.add('language-none'));
+      const noLanguageCode = element.querySelectorAll('pre code:not([class*="language-"])');
+      Array.prototype.forEach.call(noLanguageCode, x => x.classList.add('language-none'));
       Prism.highlightAllUnder(element);
     }
   }


### PR DESCRIPTION
This fix runtime error on IE11 submited on #170