### PR TITLE
Add katex to support LaTeX

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -23,7 +23,9 @@
     "prism.js"
   ],
   "dependencies": {
+    "@types/katex": "^0.10.2",
     "@types/marked": "^0.6.5",
+    "katex": "^0.11.1",
     "marked": "^0.7.0",
     "prismjs": "^1.16.0"
   },

--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -25,11 +25,17 @@ export class MarkdownComponent implements OnChanges, AfterViewInit {
   @Input() line: string | string[];
   @Input() lineOffset: number;
 
+  // Plugin - katex
+  @Input()
+  get useKatex(): boolean { return this._useKatex; }
+  set useKatex(value: boolean) { this._useKatex = this.coerceBooleanProperty(value); }
+
   @Output() error = new EventEmitter<string>();
   @Output() load = new EventEmitter<string>();
 
   private _lineHighlight = false;
   private _lineNumbers = false;
+  private _useKatex = false;
 
   constructor(
     public element: ElementRef<HTMLElement>,
@@ -54,7 +60,8 @@ export class MarkdownComponent implements OnChanges, AfterViewInit {
   }
 
   render(markdown: string, decodeHtml = false) {
-    this.element.nativeElement.innerHTML = this.markdownService.compile(markdown, decodeHtml);
+    this.element.nativeElement.innerHTML = this.markdownService.compile(
+      markdown, decodeHtml, this.useKatex);
     this.handlePlugins();
     this.markdownService.highlight(this.element.nativeElement);
   }


### PR DESCRIPTION
To solve my issue #181 of having LaTeX in ngx-markdown I propose to add katex, which allows to write $f(x) = e^x$ (at the beginning of a line) and replaced by the LaTeX equation.

To use katex, "useKatex" should be included like 
```
<markdown [data]="..." useKatex></markdown>
```

and to the angular.json file the katex css should be added like

```
...
"styles": [
  ...,
  "node_modules/katex/dist/katex.css"
]
```

Katex is included by applying it in the compile() function after precompile and before using marked. 