### PR TITLE
Update marked 8

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2019 Jean-Francois Cere
+Copyright (c) 2017-2020 Jean-Francois Cere
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -236,16 +236,16 @@ imports: [
 
 As per ngx-markdown v9.0.0 **sanitization is enabled by default** and uses Angular `DomSanitizer` with `SecurityContext.HTML` to avoid XSS vulnerabilities. The `SecurityContext` level can be changed using the `sanitize` property when configuring `MarkdownModule`.
 
-For example, to turn off sanitization simply provide `SecurityContext.NONE`.
-
-```diff
+```typescript
 import { SecurityContext } from '@angular/core';
 
-imports: [
-  MarkdownModule.forRoot({
-+   sanitize: SecurityContext.NONE,
-  }),
-]
+// enable default sanitization
+MarkdownModule.forRoot()
+
+// turn off sanitization
+MarkdownModule.forRoot({
+  sanitize: SecurityContext.NONE
+})
 ```
 
 > :blue_book: Follow [Angular DomSanitizer](https://angular.io/api/platform-browser/DomSanitizer#sanitize) documentation for more information on sanitization and security contexts.

--- a/README.md
+++ b/README.md
@@ -203,9 +203,6 @@ public options: KatexOptions = {
 
 ## Configuration
 
-> :warning: Sanitization of parsed markdown is not enabled by default which can expose your application to XSS vulnerabilities. It is recommended that you enable it by setting `sanitize: true` through [markedOptions](#markedoptions) when importing `MarkdownModule`.  
-:soon: _Take note that sanitization will be enabled by default on next major update._
-
 ### Main application module
 
 You must import `MarkdownModule` inside your main application module (usually named AppModule) with `forRoot` to be able to use `markdown` component and/or directive.
@@ -235,6 +232,24 @@ imports: [
 ],
 ```
 
+#### Sanitization
+
+As per ngx-markdown v9.0.0 **sanitization is enabled by default** and uses Angular `DomSanitizer` with `SecurityContext.HTML` to avoid XSS vulnerabilities. The `SecurityContext` level can be changed using the `sanitize` property when configuring `MarkdownModule`.
+
+For example, to turn off sanitization simply provide `SecurityContext.NONE`.
+
+```diff
+import { SecurityContext } from '@angular/core';
+
+imports: [
+  MarkdownModule.forRoot({
++   sanitize: SecurityContext.NONE,
+  }),
+]
+```
+
+> :blue_book: Follow [Angular DomSanitizer](https://angular.io/api/platform-browser/DomSanitizer#sanitize) documentation for more information on sanitization and security contexts.
+
 #### MarkedOptions
 
 Optionally, markdown parsing can be configured by passing [MarkedOptions](https://marked.js.org/#/USING_ADVANCED.md#options) to the `forRoot` method of `MarkdownModule`.
@@ -259,10 +274,8 @@ MarkdownModule.forRoot({
     provide: MarkedOptions,
     useValue: {
       gfm: true,
-      tables: true,
       breaks: false,
       pedantic: false,
-      sanitize: false,
       smartLists: true,
       smartypants: false,
     },
@@ -290,10 +303,8 @@ export function markedOptionsFactory(): MarkedOptions {
   return {
     renderer: renderer,
     gfm: true,
-    tables: true,
     breaks: false,
     pedantic: false,
-    sanitize: false,
     smartLists: true,
     smartypants: false,
   };

--- a/angular.json
+++ b/angular.json
@@ -123,7 +123,7 @@
           },
           "configurations": {
             "production": {
-              "project": "lib/ng-package.json"
+              "tsConfig": "lib/tsconfig.lib.prod.json"
             }
           }
         },

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { NgModule, SecurityContext } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { MarkdownModule, MarkedOptions, MarkedRenderer } from 'ngx-markdown';
@@ -13,16 +13,7 @@ export function markedOptions(): MarkedOptions {
     return '<blockquote class="blockquote"><p>' + text + '</p></blockquote>';
   };
 
-  return {
-    renderer: renderer,
-    gfm: true,
-    tables: true,
-    breaks: false,
-    pedantic: false,
-    sanitize: false,
-    smartLists: true,
-    smartypants: false,
-  };
+  return { renderer };
 }
 
 @NgModule({
@@ -32,10 +23,8 @@ export function markedOptions(): MarkedOptions {
     HttpClientModule,
     MarkdownModule.forRoot({
       loader: HttpClient,
-      markedOptions: {
-        provide: MarkedOptions,
-        useFactory: markedOptions,
-      },
+      markedOptions: { provide: MarkedOptions, useFactory: markedOptions },
+      sanitize: SecurityContext.HTML, // default value
     }),
   ],
   declarations: [AppComponent],

--- a/lib/package.json
+++ b/lib/package.json
@@ -24,9 +24,9 @@
     "katex"
   ],
   "dependencies": {
-    "@types/marked": "^0.7.0",
+    "@types/marked": "^0.7.2",
     "katex": "^0.11.0",
-    "marked": "^0.7.0",
+    "marked": "^0.8.0",
     "prismjs": "^1.16.0"
   },
   "peerDependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-markdown",
-  "version": "9.0.0-beta.0",
+  "version": "9.0.0-beta.1",
   "description": "Angular library that uses marked to parse markdown to html combined with Prism.js for synthax highlights",
   "homepage": "https://github.com/jfcere/ngx-markdown",
   "license": "MIT",

--- a/lib/src/markdown.component.spec.ts
+++ b/lib/src/markdown.component.spec.ts
@@ -1,4 +1,3 @@
-import { HttpClientModule } from '@angular/common/http';
 import { ElementRef } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
@@ -6,8 +5,8 @@ import { first } from 'rxjs/operators';
 
 import { KatexOptions } from './katex-options';
 import { MarkdownComponent } from './markdown.component';
+import { MarkdownModule } from './markdown.module';
 import { MarkdownService } from './markdown.service';
-import { MarkedOptions } from './marked-options';
 
 describe('MarkdownComponent', () => {
   let fixture: ComponentFixture<MarkdownComponent>;
@@ -16,11 +15,8 @@ describe('MarkdownComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientModule],
-      declarations: [MarkdownComponent],
-      providers: [
-        { provide: MarkedOptions, useValue: {} },
-        MarkdownService,
+      imports: [
+        MarkdownModule.forRoot(),
       ],
     }).compileComponents();
   }));

--- a/lib/src/markdown.module.spec.ts
+++ b/lib/src/markdown.module.spec.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { Component } from '@angular/core';
+import { Component, SecurityContext } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 
-import { initialMarkedOptions, MarkdownModule } from './markdown.module';
-import { errorSrcWithoutHttpClient } from './markdown.service';
+import { MarkdownModule } from './markdown.module';
+import { errorSrcWithoutHttpClient, SECURITY_CONTEXT } from './markdown.service';
 import { MarkedOptions } from './marked-options';
 
 @Component({
@@ -29,7 +29,7 @@ describe('MarkdownModule', () => {
 
   describe('forRoot', () => {
 
-    it('should provide HttpClientModule when MarkdownModuleConfig.loader is provided', () => {
+    it('should provide HttpClient when MarkdownModuleConfig.loader is provided', () => {
 
       TestBed.configureTestingModule({
         imports: [
@@ -43,20 +43,7 @@ describe('MarkdownModule', () => {
       expect(httpClient instanceof HttpClient).toBeTruthy();
     });
 
-    it('should not provide HttpClientModule when MarkdownModuleConfig.loader is not provided', () => {
-
-      TestBed.configureTestingModule({
-        imports: [
-          MarkdownModule.forRoot(),
-        ],
-      });
-
-      const httpClient = TestBed.inject(HttpClient, null);
-
-      expect(httpClient).toBeNull();
-    });
-
-    it('should not provide HttpClientModule when MarkdownModuleConfig.markedOptions is provided', () => {
+    it('should not provide HttpClient when MarkdownModuleConfig is provided without loader', () => {
 
       TestBed.configureTestingModule({
         imports: [
@@ -74,7 +61,20 @@ describe('MarkdownModule', () => {
       expect(httpClient).toBeNull();
     });
 
-    it('should provide marked options when provided', () => {
+    it('should not provide HttpClient when MarkdownModuleConfig is not provided', () => {
+
+      TestBed.configureTestingModule({
+        imports: [
+          MarkdownModule.forRoot(),
+        ],
+      });
+
+      const httpClient = TestBed.inject(HttpClient, null);
+
+      expect(httpClient).toBeNull();
+    });
+
+    it('should provide MarkedOptions when MarkdownModuleConfig is provided with markedOptions', () => {
 
       const mockMarkedOptions: MarkedOptions = { baseUrl: 'mock' };
 
@@ -94,20 +94,7 @@ describe('MarkdownModule', () => {
       expect(markedOptions).toBe(mockMarkedOptions);
     });
 
-    it('should provide default marked options when not provided', () => {
-
-      TestBed.configureTestingModule({
-        imports: [
-          MarkdownModule.forRoot(),
-        ],
-      });
-
-      const markedOptions = TestBed.inject(MarkedOptions);
-
-      expect(markedOptions).toEqual(initialMarkedOptions['useValue']);
-    });
-
-    it('should provide default marked options when loader is provided provided', () => {
+    it('should not provide MarkedOptions when MarkdownModuleConfig is provided without markedOptions', () => {
 
       TestBed.configureTestingModule({
         imports: [
@@ -115,9 +102,66 @@ describe('MarkdownModule', () => {
         ],
       });
 
-      const markedOptions = TestBed.inject(MarkedOptions);
+      const markedOptions = TestBed.inject(MarkedOptions, null);
 
-      expect(markedOptions).toEqual(initialMarkedOptions['useValue']);
+      expect(markedOptions).toBeNull();
+    });
+
+    it('should not provide MarkedOptions when MarkdownModuleConfig is not provided', () => {
+
+      TestBed.configureTestingModule({
+        imports: [
+          MarkdownModule.forRoot(),
+        ],
+      });
+
+      const markedOptions = TestBed.inject(MarkedOptions, null);
+
+      expect(markedOptions).toBeNull();
+    });
+
+    it('should provide SecurityContext when MarkdownModuleConfig is provided with sanitize', () => {
+
+      TestBed.configureTestingModule({
+        imports: [
+          MarkdownModule.forRoot({ sanitize: SecurityContext.NONE }),
+        ],
+      });
+
+      const securityContext = TestBed.inject(SECURITY_CONTEXT);
+
+      expect(securityContext).toBe(SecurityContext.NONE);
+    });
+
+    it('should provide default SecurityContext when MarkdownModuleConfig is provided without sanitize', () => {
+
+      TestBed.configureTestingModule({
+        imports: [
+          MarkdownModule.forRoot({
+            markedOptions: {
+              provide: MarkedOptions,
+              useValue: 'mockMarkedOptions',
+            },
+          }),
+        ],
+      });
+
+      const securityContext = TestBed.inject(SECURITY_CONTEXT);
+
+      expect(securityContext).toBe(SecurityContext.HTML);
+    });
+
+    it('should provide default SecurityContext when MarkdownModuleConfig is not provided', () => {
+
+      TestBed.configureTestingModule({
+        imports: [
+          MarkdownModule.forRoot(),
+        ],
+      });
+
+      const securityContext = TestBed.inject(SECURITY_CONTEXT);
+
+      expect(securityContext).toBe(SecurityContext.HTML);
     });
   });
 
@@ -140,6 +184,7 @@ describe('MarkdownModule', () => {
           MarkdownModule.forRoot({
             loader: HttpClient,
             markedOptions: { provide: MarkedOptions, useValue: mockMarkedOptions },
+            sanitize: SecurityContext.NONE,
           }),
           MarkdownModule.forChild(),
         ],
@@ -147,9 +192,11 @@ describe('MarkdownModule', () => {
 
       const httpClient = TestBed.inject(HttpClient);
       const markedOptions = TestBed.inject(MarkedOptions);
+      const securityContext = TestBed.inject(SECURITY_CONTEXT);
 
       expect(httpClient instanceof HttpClient).toBeTruthy();
       expect(markedOptions).toEqual(mockMarkedOptions);
+      expect(securityContext).toBe(SecurityContext.NONE);
     });
   });
 

--- a/lib/src/markdown.module.ts
+++ b/lib/src/markdown.module.ts
@@ -1,10 +1,9 @@
-import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
+import { ModuleWithProviders, NgModule, Provider, SecurityContext } from '@angular/core';
 
 import { LanguagePipe } from './language.pipe';
 import { MarkdownComponent } from './markdown.component';
 import { MarkdownPipe } from './markdown.pipe';
-import { MarkdownService } from './markdown.service';
-import { MarkedOptions } from './marked-options';
+import { MarkdownService, SECURITY_CONTEXT } from './markdown.service';
 
 // having a dependency on `HttpClientModule` within a library
 // breaks all the interceptors from the app consuming the library
@@ -13,20 +12,8 @@ import { MarkedOptions } from './marked-options';
 export interface MarkdownModuleConfig {
   loader?: Provider;
   markedOptions?: Provider;
+  sanitize?: SecurityContext;
 }
-
-export const initialMarkedOptions: Provider = {
-  provide: MarkedOptions,
-  useValue: {
-    gfm: true,
-    tables: true,
-    breaks: false,
-    pedantic: false,
-    sanitize: false,
-    smartLists: true,
-    smartypants: false,
-  },
-};
 
 const sharedDeclarations = [
   LanguagePipe,
@@ -45,7 +32,13 @@ export class MarkdownModule {
       providers: [
         MarkdownService,
         markdownModuleConfig && markdownModuleConfig.loader || [],
-        markdownModuleConfig && markdownModuleConfig.markedOptions || initialMarkedOptions,
+        markdownModuleConfig && markdownModuleConfig.markedOptions || [],
+        {
+          provide: SECURITY_CONTEXT,
+          useValue: markdownModuleConfig && markdownModuleConfig.sanitize != null
+            ? markdownModuleConfig.sanitize
+            : SecurityContext.HTML,
+        },
       ],
     };
   }

--- a/lib/src/markdown.pipe.spec.ts
+++ b/lib/src/markdown.pipe.spec.ts
@@ -1,10 +1,9 @@
-import { HttpClientModule } from '@angular/common/http';
 import { ElementRef, NgZone } from '@angular/core';
 import { fakeAsync, TestBed } from '@angular/core/testing';
 
+import { MarkdownModule } from './markdown.module';
 import { MarkdownPipe } from './markdown.pipe';
 import { MarkdownService } from './markdown.service';
-import { MarkedOptions } from './marked-options';
 
 describe('MarkdownPipe', () => {
   const elementRef = new ElementRef(document.createElement('div'));
@@ -14,10 +13,8 @@ describe('MarkdownPipe', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientModule],
-      providers: [
-        MarkdownService,
-        { provide: MarkedOptions, useValue: {} },
+      imports: [
+        MarkdownModule.forRoot(),
       ],
     });
   });

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -66,6 +66,12 @@ describe('MarkdowService', () => {
 
     describe('constructor', () => {
 
+      it('should initialize options', () => {
+
+        expect(markdownService.options).toBeDefined();
+        expect(markdownService.options.renderer).toBeDefined();
+      });
+
       it('should initialize renderer', () => {
 
         expect(markdownService.renderer).toBeDefined();

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -7,7 +7,6 @@ import { parse } from 'marked';
 import { KatexOptions } from './katex-options';
 import { MarkdownModule } from './markdown.module';
 import { errorKatexNotLoaded, MarkdownService, SECURITY_CONTEXT } from './markdown.service';
-import { MarkedRenderer } from './marked-renderer';
 
 declare var Prism: any;
 declare var katex: any;

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -5,8 +5,8 @@ import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
 import { parse } from 'marked';
 
 import { KatexOptions } from './katex-options';
-import { errorKatexNotLoaded, MarkdownService } from './markdown.service';
-import { MarkedOptions } from './marked-options';
+import { MarkdownModule } from './markdown.module';
+import { errorKatexNotLoaded, MarkdownService, SECURITY_CONTEXT } from './markdown.service';
 
 declare var Prism: any;
 declare var katex: any;
@@ -16,319 +16,329 @@ describe('MarkdowService', () => {
   let http: HttpTestingController;
   let markdownService: MarkdownService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        BrowserModule,
-        HttpClientTestingModule,
-      ],
-      providers: [
-        { provide: MarkedOptions, useValue: {} },
-        MarkdownService,
-      ],
-    });
-  });
+  describe('with SecurityContext.HTML', () => {
 
-  beforeEach(() => {
-    domSanitizer = TestBed.inject(DomSanitizer);
-    http = TestBed.inject(HttpTestingController);
-    markdownService = TestBed.inject(MarkdownService);
-  });
+    describe('compile', () => {
 
-  describe('constructor', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [
+            MarkdownModule.forRoot({ sanitize: SecurityContext.HTML }),
+          ],
+        });
+      });
 
-    it('should initialize renderer', () => {
+      beforeEach(() => {
+        domSanitizer = TestBed.inject(DomSanitizer);
+        markdownService = TestBed.inject(MarkdownService);
+      });
 
-      expect(markdownService.renderer).toBeDefined();
-    });
-  });
+      it('should sanitize parsed markdown', () => {
 
-  describe('compile', () => {
+        const securityContext = TestBed.inject(SECURITY_CONTEXT);
 
-    it('should return parsed markdown correctly', () => {
+        const mockRaw = '### Markdown-x';
+        const sanitized = domSanitizer.sanitize(securityContext, parse(mockRaw));
+        const unsanitized = parse(mockRaw);
 
-      const mockRaw = '### Markdown-x';
-
-      expect(markdownService.compile(mockRaw)).toBe(parse(mockRaw));
-    });
-
-    it('should return empty string when raw is null/undefined/empty', () => {
-
-      expect(markdownService.compile(null)).toBe('');
-      expect(markdownService.compile(undefined)).toBe('');
-      expect(markdownService.compile('')).toBe('');
-    });
-
-    it('should remove leading whitespaces offset while keeping indent', () => {
-
-      const mockRaw =  [
-        '',               // wait for line with non-whitespaces
-        '  * list',       // find first line with non-whitespaces to set offset
-        '    * sub-list', // keep indent while removing from previous row offset
-      ].join('\n');
-
-      const expected = [
-        '',
-        '* list',
-        '  * sub-list',
-      ].join('\n');
-
-      expect(markdownService.compile(mockRaw)).toBe(parse(expected));
-    });
-
-    it('should return line with indent correctly', () => {
-
-      const mockRaw =  [
-        '   ',              // first line with only whitespaces should not determine indent offset
-        '  * list',         // find first line with non-whitespaces to set offset
-        '    * sub-list',   // keep indent while removing from previous row offset
-        '  ',               // keep blank line
-        ' Negative indent', // keep line with negative offset according to first non-whitespaces line indent
-        '  Lorem Ipsum',    // keep indent like equals to first non-whitespaces line ident
-      ].join('\n');
-
-      const expected = [
-        '* list',
-        '  * sub-list',
-        '',
-        'Negative indent',
-        'Lorem Ipsum',
-      ].join('\n');
-
-      expect(markdownService.compile(mockRaw)).toBe(parse(expected));
-    });
-
-    it('should decode HTML correctly when decodeHtml is true ', () => {
-
-      const mockRaw = '&lt;html&gt;';
-      const expected = '<html>';
-
-      expect(markdownService.compile(mockRaw, true)).toBe(expected);
-    });
-
-    it('should not decode HTML when decodeHtml is omitted/false/null/undefined', () => {
-
-      const mockRaw = '&lt;html&gt;';
-      const expected = '<p>&lt;html&gt;</p>\n';
-
-      expect(markdownService.compile(mockRaw)).toBe(expected);
-      expect(markdownService.compile(mockRaw, false)).toBe(expected);
-      expect(markdownService.compile(mockRaw, null)).toBe(expected);
-      expect(markdownService.compile(mockRaw, undefined)).toBe(expected);
-    });
-
-    it('should sanitize when markedOptions.sanitize is true and no sanitizer function is provided', () => {
-
-      const markedOptions: MarkedOptions = { sanitize: true };
-      const mockRaw = '### Markdown-x';
-      const sanitized = domSanitizer.sanitize(SecurityContext.HTML, parse(mockRaw));
-      const unsanitized = parse(mockRaw);
-
-      expect(markdownService.compile(mockRaw, false, markedOptions)).toBe(sanitized);
-      expect(markdownService.compile(mockRaw, false, markedOptions)).not.toBe(unsanitized);
-    });
-
-    it('should not sanitize when markedOptions.sanitize is true but a sanitizer function is provided', () => {
-
-      const markedOptions: MarkedOptions = { sanitize: true, sanitizer: () => null };
-      const mockRaw = '### Markdown-x';
-      const expected = parse(mockRaw);
-
-      expect(markdownService.compile(mockRaw, false, markedOptions)).toBe(expected);
-    });
-
-    it('should not sanitize when markedOptions.sanitize is false regardless of whether a sanitizer function is provided or not', () => {
-
-      const mockRaw = '### Markdown-x';
-      const expected = parse(mockRaw);
-
-      expect(markdownService.compile(mockRaw, false, { sanitize: false })).toBe(expected);
-      expect(markdownService.compile(mockRaw, false, { sanitize: false, sanitizer: () => null })).toBe(expected);
-    });
-  });
-
-  describe('getSource', () => {
-
-    it('should call http service to get src content', () => {
-
-      const mockSrc = 'file-x.md';
-      const mockResponse = 'response-x';
-
-      let result: string;
-
-      markdownService
-        .getSource(mockSrc)
-        .subscribe(data => result = data);
-
-      http.expectOne(mockSrc).flush(mockResponse);
-
-      expect(result).toEqual(mockResponse);
-    });
-
-    it('should return src content with language tick when file extension is not .md', () => {
-
-      const mockSrc = './src-example/file.cpp';
-      const mockResponse = 'response-x';
-
-      let result: string;
-
-      markdownService
-        .getSource(mockSrc)
-        .subscribe(data => result = data);
-
-      http.expectOne(mockSrc).flush(mockResponse);
-
-      expect(result).toEqual('```cpp\n' + mockResponse + '\n```');
-    });
-
-    it('should return src content without language tick when file extension is .md', () => {
-
-      const mockSrc = './src-example/file.md';
-      const mockResponse = 'response-x';
-
-      let result: string;
-
-      markdownService
-        .getSource(mockSrc)
-        .subscribe(data => result = data);
-
-      http.expectOne(mockSrc).flush(mockResponse);
-
-      expect(result).toEqual(mockResponse);
-    });
-
-    it('should ignore query parameters when resolving file extension', () => {
-
-      const mockSrc = './src-example/file.js?param=123&another=abc';
-      const mockResponse = 'response-x';
-
-      let result: string;
-
-      markdownService
-        .getSource(mockSrc)
-        .subscribe(data => result = data);
-
-      http.expectOne(mockSrc).flush(mockResponse);
-
-      expect(result).toEqual('```js\n' + mockResponse + '\n```');
-    });
-  });
-
-  describe('highlight', () => {
-
-    it('should not call Prism when not available', () => {
-
-      const mockHtmlElement = document.createElement('div');
-
-      global['Prism'] = undefined;
-
-      expect(() => markdownService.highlight(mockHtmlElement)).not.toThrow();
-    });
-
-    it('should add `language-none` class on code blocks with no language class', () => {
-
-      const preElement = document.createElement('pre');
-      const codeElement = document.createElement('code');
-      preElement.appendChild(codeElement);
-
-      global['Prism'] = { highlightAllUnder: () => {} };
-
-      markdownService.highlight(preElement);
-
-      expect(codeElement.classList).toContain('language-none');
-    });
-
-    it('should not add `language-none` class on code blocks with language class', () => {
-
-      const preElement = document.createElement('pre');
-      const codeElement = document.createElement('code');
-      codeElement.classList.add('language-mock');
-      preElement.appendChild(codeElement);
-
-      global['Prism'] = { highlightAllUnder: () => {} };
-
-      markdownService.highlight(preElement);
-
-      expect(codeElement.classList).not.toContain('language-none');
-      expect(codeElement.classList).toContain('language-mock');
-    });
-
-    it('should not add `language-none` class on element other than code blocks without language class', () => {
-
-      const divElement = document.createElement('div');
-      const codeElement = document.createElement('code');
-      codeElement.classList.add('language-mock');
-      divElement.appendChild(codeElement);
-
-      global['Prism'] = { highlightAllUnder: () => {} };
-
-      markdownService.highlight(divElement);
-
-      expect(codeElement.classList).not.toContain('language-none');
-      expect(codeElement.classList).toContain('language-mock');
-    });
-
-    it('should call Prism when available and element parameter is present', () => {
-
-      const mockHtmlElement = document.createElement('div');
-
-      global['Prism'] = { highlightAllUnder: () => {} };
-
-      spyOn(Prism, 'highlightAllUnder');
-
-      markdownService.highlight(mockHtmlElement);
-
-      expect(Prism.highlightAllUnder).toHaveBeenCalledWith(mockHtmlElement);
-    });
-
-    it('should call Prism when available and element parameter is ommited/null/undefined', () => {
-
-      global['Prism'] = { highlightAllUnder: () => {} };
-
-      spyOn(Prism, 'highlightAllUnder');
-
-      const useCases = [
-        () => markdownService.highlight(),
-        () => markdownService.highlight(null),
-        () => markdownService.highlight(undefined),
-      ];
-
-      useCases.forEach(func => {
-        func();
-        expect(Prism.highlightAllUnder).toHaveBeenCalledWith(document);
-        Prism.highlightAllUnder.calls.reset();
+        expect(markdownService.compile(mockRaw, false)).toBe(sanitized);
+        expect(markdownService.compile(mockRaw, false)).not.toBe(unsanitized);
       });
     });
   });
 
-  describe('renderKatex', () => {
+  describe('with SecurityContext.NONE', () => {
 
-    it('should throw when katex is called but not loaded', () => {
-
-      global['katex'] = undefined;
-
-      expect(() => markdownService.renderKatex('$example$')).toThrowError(errorKatexNotLoaded);
-
-      global['katex'] = { renderToString: undefined };
-
-      expect(() => markdownService.renderKatex('$example$')).toThrowError(errorKatexNotLoaded);
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          BrowserModule,
+          HttpClientTestingModule,
+          MarkdownModule.forRoot({ sanitize: SecurityContext.NONE }),
+        ],
+      });
     });
 
-    it('should call katex with math expressions', () => {
+    beforeEach(() => {
+      http = TestBed.inject(HttpTestingController);
+      markdownService = TestBed.inject(MarkdownService);
+    });
 
-      global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
+    describe('constructor', () => {
 
-      spyOn(katex, 'renderToString');
+      it('should initialize renderer', () => {
 
-      const useCases = [
-        { tex: '$E=mc^2$' },
-        { tex: '$x^2 + y^2 = z^2$', options: { displayMode: true } },
-      ];
+        expect(markdownService.renderer).toBeDefined();
+      });
+    });
 
-      useCases.forEach(useCase => {
-        markdownService.renderKatex(useCase.tex, useCase.options);
-        expect(katex.renderToString).toHaveBeenCalledWith(useCase.tex.replace(/\$/gm, ''), useCase.options);
-        katex.renderToString.calls.reset();
+    describe('compile', () => {
+
+      it('should return parsed markdown correctly', () => {
+
+        const mockRaw = '### Markdown-x';
+
+        expect(markdownService.compile(mockRaw)).toBe(parse(mockRaw));
+      });
+
+      it('should return empty string when raw is null/undefined/empty', () => {
+
+        expect(markdownService.compile(null)).toBe('');
+        expect(markdownService.compile(undefined)).toBe('');
+        expect(markdownService.compile('')).toBe('');
+      });
+
+      it('should remove leading whitespaces offset while keeping indent', () => {
+
+        const mockRaw =  [
+          '',               // wait for line with non-whitespaces
+          '  * list',       // find first line with non-whitespaces to set offset
+          '    * sub-list', // keep indent while removing from previous row offset
+        ].join('\n');
+
+        const expected = [
+          '',
+          '* list',
+          '  * sub-list',
+        ].join('\n');
+
+        expect(markdownService.compile(mockRaw)).toBe(parse(expected));
+      });
+
+      it('should return line with indent correctly', () => {
+
+        const mockRaw =  [
+          '   ',              // first line with only whitespaces should not determine indent offset
+          '  * list',         // find first line with non-whitespaces to set offset
+          '    * sub-list',   // keep indent while removing from previous row offset
+          '  ',               // keep blank line
+          ' Negative indent', // keep line with negative offset according to first non-whitespaces line indent
+          '  Lorem Ipsum',    // keep indent like equals to first non-whitespaces line ident
+        ].join('\n');
+
+        const expected = [
+          '* list',
+          '  * sub-list',
+          '',
+          'Negative indent',
+          'Lorem Ipsum',
+        ].join('\n');
+
+        expect(markdownService.compile(mockRaw)).toBe(parse(expected));
+      });
+
+      it('should decode HTML correctly when decodeHtml is true ', () => {
+
+        const mockRaw = '&lt;html&gt;';
+        const expected = '<html>';
+
+        expect(markdownService.compile(mockRaw, true)).toBe(expected);
+      });
+
+      it('should not decode HTML when decodeHtml is omitted/false/null/undefined', () => {
+
+        const mockRaw = '&lt;html&gt;';
+        const expected = '<p>&lt;html&gt;</p>\n';
+
+        expect(markdownService.compile(mockRaw)).toBe(expected);
+        expect(markdownService.compile(mockRaw, false)).toBe(expected);
+        expect(markdownService.compile(mockRaw, null)).toBe(expected);
+        expect(markdownService.compile(mockRaw, undefined)).toBe(expected);
+      });
+
+      it('should not sanitize parsed markdown', () => {
+
+        const mockRaw = '### Markdown-x';
+        const expected = parse(mockRaw);
+
+        expect(markdownService.compile(mockRaw, false)).toBe(expected);
+        expect(markdownService.compile(mockRaw, false)).toBe(expected);
+      });
+    });
+
+    describe('getSource', () => {
+
+      it('should call http service to get src content', () => {
+
+        const mockSrc = 'file-x.md';
+        const mockResponse = 'response-x';
+
+        let result: string;
+
+        markdownService
+          .getSource(mockSrc)
+          .subscribe(data => result = data);
+
+        http.expectOne(mockSrc).flush(mockResponse);
+
+        expect(result).toEqual(mockResponse);
+      });
+
+      it('should return src content with language tick when file extension is not .md', () => {
+
+        const mockSrc = './src-example/file.cpp';
+        const mockResponse = 'response-x';
+
+        let result: string;
+
+        markdownService
+          .getSource(mockSrc)
+          .subscribe(data => result = data);
+
+        http.expectOne(mockSrc).flush(mockResponse);
+
+        expect(result).toEqual('```cpp\n' + mockResponse + '\n```');
+      });
+
+      it('should return src content without language tick when file extension is .md', () => {
+
+        const mockSrc = './src-example/file.md';
+        const mockResponse = 'response-x';
+
+        let result: string;
+
+        markdownService
+          .getSource(mockSrc)
+          .subscribe(data => result = data);
+
+        http.expectOne(mockSrc).flush(mockResponse);
+
+        expect(result).toEqual(mockResponse);
+      });
+
+      it('should ignore query parameters when resolving file extension', () => {
+
+        const mockSrc = './src-example/file.js?param=123&another=abc';
+        const mockResponse = 'response-x';
+
+        let result: string;
+
+        markdownService
+          .getSource(mockSrc)
+          .subscribe(data => result = data);
+
+        http.expectOne(mockSrc).flush(mockResponse);
+
+        expect(result).toEqual('```js\n' + mockResponse + '\n```');
+      });
+    });
+
+    describe('highlight', () => {
+
+      it('should not call Prism when not available', () => {
+
+        const mockHtmlElement = document.createElement('div');
+
+        global['Prism'] = undefined;
+
+        expect(() => markdownService.highlight(mockHtmlElement)).not.toThrow();
+      });
+
+      it('should add `language-none` class on code blocks with no language class', () => {
+
+        const preElement = document.createElement('pre');
+        const codeElement = document.createElement('code');
+        preElement.appendChild(codeElement);
+
+        global['Prism'] = { highlightAllUnder: () => {} };
+
+        markdownService.highlight(preElement);
+
+        expect(codeElement.classList).toContain('language-none');
+      });
+
+      it('should not add `language-none` class on code blocks with language class', () => {
+
+        const preElement = document.createElement('pre');
+        const codeElement = document.createElement('code');
+        codeElement.classList.add('language-mock');
+        preElement.appendChild(codeElement);
+
+        global['Prism'] = { highlightAllUnder: () => {} };
+
+        markdownService.highlight(preElement);
+
+        expect(codeElement.classList).not.toContain('language-none');
+        expect(codeElement.classList).toContain('language-mock');
+      });
+
+      it('should not add `language-none` class on element other than code blocks without language class', () => {
+
+        const divElement = document.createElement('div');
+        const codeElement = document.createElement('code');
+        codeElement.classList.add('language-mock');
+        divElement.appendChild(codeElement);
+
+        global['Prism'] = { highlightAllUnder: () => {} };
+
+        markdownService.highlight(divElement);
+
+        expect(codeElement.classList).not.toContain('language-none');
+        expect(codeElement.classList).toContain('language-mock');
+      });
+
+      it('should call Prism when available and element parameter is present', () => {
+
+        const mockHtmlElement = document.createElement('div');
+
+        global['Prism'] = { highlightAllUnder: () => {} };
+
+        spyOn(Prism, 'highlightAllUnder');
+
+        markdownService.highlight(mockHtmlElement);
+
+        expect(Prism.highlightAllUnder).toHaveBeenCalledWith(mockHtmlElement);
+      });
+
+      it('should call Prism when available and element parameter is ommited/null/undefined', () => {
+
+        global['Prism'] = { highlightAllUnder: () => {} };
+
+        spyOn(Prism, 'highlightAllUnder');
+
+        const useCases = [
+          () => markdownService.highlight(),
+          () => markdownService.highlight(null),
+          () => markdownService.highlight(undefined),
+        ];
+
+        useCases.forEach(func => {
+          func();
+          expect(Prism.highlightAllUnder).toHaveBeenCalledWith(document);
+          Prism.highlightAllUnder.calls.reset();
+        });
+      });
+    });
+
+    describe('renderKatex', () => {
+
+      it('should throw when katex is called but not loaded', () => {
+
+        global['katex'] = undefined;
+
+        expect(() => markdownService.renderKatex('$example$')).toThrowError(errorKatexNotLoaded);
+
+        global['katex'] = { renderToString: undefined };
+
+        expect(() => markdownService.renderKatex('$example$')).toThrowError(errorKatexNotLoaded);
+      });
+
+      it('should call katex with math expressions', () => {
+
+        global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
+
+        spyOn(katex, 'renderToString');
+
+        const useCases = [
+          { tex: '$E=mc^2$' },
+          { tex: '$x^2 + y^2 = z^2$', options: { displayMode: true } },
+        ];
+
+        useCases.forEach(useCase => {
+          markdownService.renderKatex(useCase.tex, useCase.options);
+          expect(katex.renderToString).toHaveBeenCalledWith(useCase.tex.replace(/\$/gm, ''), useCase.options);
+          katex.renderToString.calls.reset();
+        });
       });
     });
   });

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -30,17 +30,13 @@ export class MarkdownService {
 
   private readonly initialMarkedOptions: MarkedOptions = {
     renderer: new MarkedRenderer(),
-    smartLists: true,
   };
 
   private _options: MarkedOptions;
+
   get options(): MarkedOptions { return this._options; }
   set options(value: MarkedOptions) {
-    this._options = Object.assign({},
-      { ...this.initialMarkedOptions },
-      this._options,
-      value,
-    );
+    this._options = { ...this.initialMarkedOptions, ...value };
   }
 
   get renderer(): MarkedRenderer { return this.options.renderer; }

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -1,6 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { Inject, Injectable, Optional, PLATFORM_ID, SecurityContext } from '@angular/core';
+import { Inject, Injectable, InjectionToken, Optional, PLATFORM_ID, SecurityContext } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import * as marked from 'marked';
 import { Observable } from 'rxjs';
@@ -23,14 +23,21 @@ export const errorKatexNotLoaded = '[ngx-markdown When using the [katex] attribu
 export const errorSrcWithoutHttpClient = '[ngx-markdown] When using the [src] attribute you *have to* pass the `HttpClient` as a parameter of the `forRoot` method. See README for more information';
 // tslint:enable:max-line-length
 
+export const SECURITY_CONTEXT = new InjectionToken<SecurityContext>('SECURITY_CONTEXT');
+
 @Injectable()
 export class MarkdownService {
+
+  private readonly initialMarkedOptions: MarkedOptions = {
+    renderer: new MarkedRenderer(),
+    smartLists: true,
+  };
 
   private _options: MarkedOptions;
   get options(): MarkedOptions { return this._options; }
   set options(value: MarkedOptions) {
     this._options = Object.assign({},
-      { renderer: new MarkedRenderer() },
+      { ...this.initialMarkedOptions },
       this._options,
       value,
     );
@@ -43,20 +50,19 @@ export class MarkdownService {
 
   constructor(
     @Inject(PLATFORM_ID) private platform: Object,
+    @Inject(SECURITY_CONTEXT) private securityContext: SecurityContext,
     @Optional() private http: HttpClient,
-    private domSanitizer: DomSanitizer,
-    options: MarkedOptions,
+    @Optional() options: MarkedOptions,
+    private sanitizer: DomSanitizer,
   ) {
     this.options = options;
   }
 
   compile(markdown: string, decodeHtml = false, markedOptions = this.options): string {
-    let precompiled = this.trimIndentation(markdown);
-    precompiled = decodeHtml ? this.decodeHtml(precompiled) : precompiled;
-    const compiled = marked.parse(precompiled, markedOptions);
-    return markedOptions.sanitize && !markedOptions.sanitizer
-      ? this.domSanitizer.sanitize(SecurityContext.HTML, compiled)
-      : compiled;
+    const trimmed = this.trimIndentation(markdown);
+    const decoded = decodeHtml ? this.decodeHtml(trimmed) : trimmed;
+    const compiled = marked.parse(decoded, markedOptions);
+    return this.sanitizer.sanitize(this.securityContext, compiled);
   }
 
   getSource(src: string): Observable<string> {

--- a/lib/src/marked-options.ts
+++ b/lib/src/marked-options.ts
@@ -49,11 +49,6 @@ export class MarkedOptions {
   renderer?: MarkedRenderer;
 
   /**
-   * Sanitize the output. Ignore any HTML that has been input.
-   */
-  sanitize?: boolean;
-
-  /**
    * Shows an HTML error message when rendering fails.
    */
   silent?: boolean;
@@ -69,11 +64,6 @@ export class MarkedOptions {
   smartypants?: boolean;
 
   /**
-   * Enable GFM tables. This option requires the gfm option to be true.
-   */
-  tables?: boolean;
-
-  /**
    * Generate closing slash for self-closing tags (<br/> instead of <br>)
    */
   xhtml?: boolean;
@@ -82,9 +72,4 @@ export class MarkedOptions {
    * A function to highlight code blocks. The function takes three arguments: code, lang, and callback.
    */
   highlight?(code: string, lang: string, callback?: (error: any | undefined, code: string) => void): string;
-
-  /**
-   * Optionally sanitize found HTML with a sanitizer function.
-   */
-  sanitizer?(html: string): string;
 }

--- a/lib/tsconfig.lib.json
+++ b/lib/tsconfig.lib.json
@@ -17,7 +17,6 @@
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "enableResourceInlining": true,
-    "enableIvy": false
   },
   "exclude": [
     "test.ts",

--- a/lib/tsconfig.lib.prod.json
+++ b/lib/tsconfig.lib.prod.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "angularCompilerOptions": {
+    "enableIvy": false
+  },
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ng": "ng",
     "start": "yarn link:lib && ng serve",
     "build:demo": "ng build demo",
-    "build:lib": "ng build lib",
+    "build:lib": "ng build lib --prod",
     "postbuild:lib": "cpx ./README.md ./dist/lib && cpx ./LICENSE ./dist/lib",
     "link:lib": "rimraf node_modules/ngx-markdown && linklocal",
     "lint": "yarn lint:lib && yarn lint:demo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-markdown",
-  "version": "9.0.0-beta.0",
+  "version": "9.0.0-beta.1",
   "description": "Angular library that uses marked to parse markdown to html combined with Prism.js for synthax highlights",
   "homepage": "https://github.com/jfcere/ngx-markdown",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,7 +1128,7 @@
   dependencies:
     "@types/sizzle" "*"
 
-"@types/marked@^0.7.0":
+"@types/marked@^0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.7.2.tgz#1393f076773b55cc7078c0fbeb86a497c69db97e"
   integrity sha512-A3EDyNaq6OCcpaOia2HQ/tu2QYt8DKuj4ExP21VU3cU3HTo2FLslvbqa2T1vux910RHvuSVqpwKnnykSFcRWOA==
@@ -5786,10 +5786,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
-  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
+marked@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.0.tgz#ec5c0c9b93878dc52dd54be8d0e524097bd81a99"
+  integrity sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==
 
 materialize-css@~0.100.2:
   version "0.100.2"
@@ -6201,9 +6201,9 @@ ng-packagr@^9.0.0:
 "ngx-markdown@file:./lib":
   version "9.0.0-beta.0"
   dependencies:
-    "@types/marked" "^0.7.0"
+    "@types/marked" "^0.7.2"
     katex "^0.11.0"
-    marked "^0.7.0"
+    marked "^0.8.0"
     prismjs "^1.16.0"
 
 nice-try@^1.0.4:


### PR DESCRIPTION
### ⚠️ Breaking changes
The following modifications has been done to `MarkdownModule` configuration:
- Removed `MarkedOptions.tables` option (now enabled with `gfm`)
- Removed `MarkedOptions.sanitize` and `sanitizer` options (deprecated by marked.js)
- Changed `MarkedOptions.smartLists` default value to `false` (to be inline with marked.js)
- Added `sanitize` option to specify `SecurityContext` when sanitizing (defaulted to `SecurityContext.HTML`)