### PR TITLE
Add optional parameters to turn off url checking

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -160,5 +160,8 @@
       }
     }
   },
-  "defaultProject": "demo"
+  "defaultProject": "demo",
+  "cli": {
+    "analytics": "a37f7c79-b9c2-431a-9f25-6994b70315a6"
+  }
 }

--- a/demo/src/app/bindings/bindings.component.html
+++ b/demo/src/app/bindings/bindings.component.html
@@ -27,6 +27,8 @@
     </markdown>
 
     <div markdown [src]="'app/bindings/remote/demo.cpp'"></div>
+
+    <div>Tips: The default loading method will check the file suffix of the url to handle the loading of non-markdown files. If you want to turn off this check, please configure <code>ignoreFileExtensionCheck</code> to <code>true</code></div>
   </section>
 
   <section>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stringke/ngx-markdown",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Angular library that uses marked to parse markdown to html combined with Prism.js for synthax highlights",
   "homepage": "https://github.com/jfcere/ngx-markdown",
   "license": "MIT",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-markdown",
+  "name": "@stringke/ngx-markdown",
   "version": "11.0.1",
   "description": "Angular library that uses marked to parse markdown to html combined with Prism.js for synthax highlights",
   "homepage": "https://github.com/jfcere/ngx-markdown",

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -39,12 +39,18 @@ export class MarkdownService {
 
   private _options: MarkedOptions | undefined;
 
-  get options(): MarkedOptions { return this._options!; }
-  set options(value: MarkedOptions) {
-    this._options = { ...this.initialMarkedOptions, ...value };
+  get options(): MarkedOptions {
+    return this._options!;
   }
 
-  get renderer(): MarkedRenderer { return this.options.renderer!; }
+  set options(value: MarkedOptions) {
+    this._options = {...this.initialMarkedOptions, ...value};
+  }
+
+  get renderer(): MarkedRenderer {
+    return this.options.renderer!;
+  }
+
   set renderer(value: MarkedRenderer) {
     this.options.renderer = value;
   }
@@ -59,7 +65,7 @@ export class MarkdownService {
     this.options = options;
   }
 
-  compile(markdown: string, decodeHtml = false, emojify = false,  markedOptions = this.options): string {
+  compile(markdown: string, decodeHtml = false, emojify = false, markedOptions = this.options): string {
     const trimmed = this.trimIndentation(markdown);
     const decoded = decodeHtml ? this.decodeHtml(trimmed) : trimmed;
     const emojified = emojify ? this.renderEmoji(decoded) : decoded;
@@ -72,7 +78,7 @@ export class MarkdownService {
       throw new Error(errorSrcWithoutHttpClient);
     }
     return this.http
-      .get(src, { responseType: 'text' })
+      .get(src, {responseType: 'text'})
       .pipe(map(markdown => this.handleExtension(src, markdown)));
   }
 
@@ -110,6 +116,12 @@ export class MarkdownService {
   }
 
   private handleExtension(src: string, markdown: string): string {
+    if (
+      (this.options.ignoreFileExtensionCheckFn && this.options.ignoreFileExtensionCheckFn(src)) ||
+      this.options.ignoreFileExtensionCheck) {
+      return markdown;
+    }
+
     const extension = src
       ? src.split('?')[0].split('.').splice(-1).join()
       : null;

--- a/lib/src/marked-options.ts
+++ b/lib/src/marked-options.ts
@@ -69,6 +69,16 @@ export class MarkedOptions {
   xhtml?: boolean;
 
   /**
+   * Ignore url suffix check when web request to load markdown file, ignore file extension check
+   */
+  ignoreFileExtensionCheck?: boolean;
+
+  /**
+   * ignore file extension check function
+   */
+  ignoreFileExtensionCheckFn?(url: string): boolean;
+
+  /**
    * A function to highlight code blocks. The function takes three arguments: code, lang, and callback.
    */
   highlight?(code: string, lang: string, callback?: (error: any | undefined, code: string) => void): string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stringke/ngx-markdown",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Angular library that uses marked to parse markdown to html combined with Prism.js for synthax highlights",
   "homepage": "https://github.com/jfcere/ngx-markdown",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-markdown",
+  "name": "@stringke/ngx-markdown",
   "version": "11.0.1",
   "description": "Angular library that uses marked to parse markdown to html combined with Prism.js for synthax highlights",
   "homepage": "https://github.com/jfcere/ngx-markdown",


### PR DESCRIPTION
before:

If your markdown file URL is similar to `http://demo.com/md/110`, the default logic will eventually check whether the url contains a suffix like .md, and if it exists, some additional content will be spliced

after:

Adding ignoreFileExtensionCheck and ignoreFileExtensionCheckFn will limit the use of ignoreFileExtensionCheckFn to check whether to ignore file extensions