### PR TITLE
Fix stripped HTML using pipe

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,6 +72,7 @@
             }
           ]
         }],
+        "semi": ["error", "always"],
         "sort-imports": ["error", {
           "ignoreCase": true,
           "ignoreDeclarationSort": true

--- a/lib/src/markdown.pipe.spec.ts
+++ b/lib/src/markdown.pipe.spec.ts
@@ -1,11 +1,13 @@
 import { ElementRef, NgZone } from '@angular/core';
 import { fakeAsync, TestBed } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { MarkdownModule } from './markdown.module';
 import { MarkdownPipe } from './markdown.pipe';
 import { MarkdownService } from './markdown.service';
 
 describe('MarkdownPipe', () => {
+  let domSanitizer: DomSanitizer;
   const elementRef = new ElementRef(document.createElement('div'));
   let markdownService: MarkdownService;
   let pipe: MarkdownPipe;
@@ -20,9 +22,10 @@ describe('MarkdownPipe', () => {
   });
 
   beforeEach(() => {
+    domSanitizer = TestBed.inject(DomSanitizer);
     markdownService = TestBed.inject(MarkdownService);
     zone = TestBed.inject(NgZone);
-    pipe = new MarkdownPipe(elementRef, markdownService, zone);
+    pipe = new MarkdownPipe(domSanitizer, elementRef, markdownService, zone);
   });
 
   it('should return empty string when value is null/undefined', () => {
@@ -68,12 +71,15 @@ describe('MarkdownPipe', () => {
 
     const markdown = '# Markdown';
     const mockCompiled = 'compiled-x';
+    const mockBypassSecurity = 'bypass-x';
 
     spyOn(markdownService, 'compile').and.returnValue(mockCompiled);
+    spyOn(domSanitizer, 'bypassSecurityTrustHtml').and.returnValue(mockBypassSecurity);
 
     const result = pipe.transform(markdown);
 
     expect(markdownService.compile).toHaveBeenCalledWith(markdown);
-    expect(result).toBe(mockCompiled);
+    expect(domSanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(mockCompiled);
+    expect(result).toBe(mockBypassSecurity);
   });
 });

--- a/lib/src/markdown.pipe.ts
+++ b/lib/src/markdown.pipe.ts
@@ -1,4 +1,5 @@
 import { ElementRef, NgZone, Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { first } from 'rxjs/operators';
 
 import { MarkdownService } from './markdown.service';
@@ -9,12 +10,13 @@ import { MarkdownService } from './markdown.service';
 export class MarkdownPipe implements PipeTransform {
 
   constructor(
+    private domSanitizer: DomSanitizer,
     private elementRef: ElementRef<HTMLElement>,
     private markdownService: MarkdownService,
     private zone: NgZone,
   ) { }
 
-  transform(value: string): string {
+  transform(value: string): SafeHtml {
     if (value == null) {
       return '';
     }
@@ -30,6 +32,6 @@ export class MarkdownPipe implements PipeTransform {
       .pipe(first())
       .subscribe(() => this.markdownService.highlight(this.elementRef.nativeElement));
 
-    return markdown;
+    return this.domSanitizer.bypassSecurityTrustHtml(markdown);
   }
 }


### PR DESCRIPTION
Because `MarkdownPipe` uses the `MarkdownService` to parse markdown to HTML, and it is already being sanitized in the service, it is safe to use `bypassSecurityTrustHtml` in `MarkdownPipe` to avoid HTML being stripped by Angular default sanitization behavior when using `innerHTML`.

Fix #126