### PR TITLE
Latex Rendering Math 

### DIFF
--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -70,6 +70,11 @@ export class MarkdownComponent implements OnChanges, AfterViewInit {
     public markdownService: MarkdownService,
   ) { }
 
+  ngOnInit(): void {
+    this.katexOptions = new KatexOptions();
+    this.katexOptions['displayMode'] = false;
+  }
+
   ngOnChanges(): void {
     if (this.data != null) {
       this.handleData();

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -91,6 +91,7 @@ export class MarkdownService {
   }
 
   renderKatex(html: string, options?: KatexOptions): string {
+    console.log("Just testing if this works.");
     if (!isPlatformBrowser(this.platform)) {
       return html;
     }

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -91,14 +91,21 @@ export class MarkdownService {
   }
 
   renderKatex(html: string, options?: KatexOptions): string {
-    console.log("Just testing if this works.");
     if (!isPlatformBrowser(this.platform)) {
       return html;
     }
     if (typeof katex === 'undefined' || typeof katex.renderToString === 'undefined') {
       throw new Error(errorKatexNotLoaded);
     }
-    return html.replace(/\$([^\s][^$]*?[^\s])\$/gm, (_, tex) => katex.renderToString(tex, options));
+    const inlineLatexRegex = /\$([^\s]*?[^$]*?[^\s]*?)\$/gm;
+    const displayLatexRegex = /\$\$([^\s]*?[^$]*?[^\s]*?)\$\$/;
+    //Replace display mode math first.
+    options!['displayMode'] = true;
+    const replaceDisplayMode = html.replace(displayLatexRegex, (_, tex) => katex.renderToString(tex, options));
+    console.log("REPLACED DISPLAY MODE:", replaceDisplayMode);
+    options!['displayMode'] = false;
+    const fullLatexProcessed = replaceDisplayMode.replace(inlineLatexRegex, (_, tex) => katex.renderToString(tex, options));
+    return fullLatexProcessed;
   }
 
   private decodeHtml(html: string): string {


### PR DESCRIPTION
Currently, utilizing the `katex` directive doesn't render two important kinds of expressions in a given markdown file:

- Single-variable latex expressions, e.g `$x$`. The markdown file loads, but the expression is not rendered as Latex.
- Display-mode expressions with double dollar signs: e.g. `$$ \sum_{i=1}^{n} x $$`. This will cause an error like this: kaTeX parse error: Can't use function '$' in math mode at position 1.

Both cases above do not render because the regex `/\$([^\s][^$]*?[^\s])\$/gm` in the `renderKatex` method in ngx-markdown.mjs does not properly capture either expression. I edited this workflow so that display-mode math is converted first, followed by in-line math- this should now render both single-variable expressions and display-mode math. 