### PR TITLE
Add mermaid integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ ngx-markdown is an [Angular](https://angular.io/) library that combines...
 - [Prism.js](http://prismjs.com/) for language syntax highlight
 - [Emoji-Toolkit](https://github.com/joypixels/emoji-toolkit) for emoji support
 - [KaTeX](https://katex.org/) for math expression rendering
+- [Mermaid](https://mermaid-js.github.io/) for diagrams and charts visualization
 
 Demo available @ [https://jfcere.github.io/ngx-markdown](https://jfcere.github.io/ngx-markdown)  
 StackBlitz available @ [https://stackblitz.com/edit/ngx-markdown](https://stackblitz.com/edit/ngx-markdown)
@@ -281,7 +282,7 @@ If you are using [Angular CLI](https://cli.angular.io/) you can follow the `angu
 
 #### KaTeX plugin
 
-Using `markdown` component and/or directive, you will be able to use the `katex` property to activate [KaTeX](https://katex.org/) plugin that render mathematical expression to HTML.
+Using `markdown` component and/or directive, you will be able to use the `katex` property to activate [KaTeX](https://katex.org/) plugin that renders mathematical expression to HTML.
 
 ```html
 <markdown
@@ -312,6 +313,56 @@ public options: KatexOptions = {
 ```
 
 > :blue_book: Follow official [KaTeX options](https://katex.org/docs/options.html) documentation for more details on the available options.
+
+### Diagrams tool
+
+> :bell: Diagram support is **optional**, skip this step if you are not planning to use it
+
+To activate [Mermaid](https://mermaid-js.github.io/) diagramming and charting tool you will need to include...
+- Mermaid JavaScript library - `node_modules/mermaid/dist/mermaid.min.js` file
+
+If you are using [Angular CLI](https://cli.angular.io/) you can follow the `angular.json` example below...
+
+```diff
+"scripts": [
+  "node_modules/marked/marked.min.js",
++ "node_modules/mermaid/dist/mermaid.min.js",
+]
+```
+
+#### Mermaid plugin
+
+Using `markdown` component and/or directive, you will be able to use the `mermaid` property to activate [Mermaid](https://mermaid-js.github.io/) plugin that renders Markdown-inspired text definitions to create and modify diagrams dynamically.
+
+```html
+<markdown
+  mermaid
+  [src]="path/to/file.md">
+</markdown>
+```
+
+Optionally, you can specify mermaid [configuration options](https://mermaid-js.github.io/mermaid/#/Setup?id=configuration) using `mermaidOptions` property.
+
+```typescript
+import { MermaidAPI } from 'ngx-markdown';
+
+public options: MermaidAPI.Config = {
+  fontFamily: '"trebuchet ms", verdana, arial, sans-serif',
+  logLevel: MermaidAPI.LogLevel.Info,
+  theme: MermaidAPI.Theme.Dark,
+  ...
+};
+```
+
+```html
+<markdown
+  mermaid
+  [mermaidOptions]="options"
+  [src]="'path/to/file.md'">
+</markdown>
+```
+
+> :blue_book: Follow official [Mermaid](https://mermaid-js.github.io/) documentation for more details on diagrams and charts syntax.
 
 ## Configuration
 

--- a/angular.json
+++ b/angular.json
@@ -50,6 +50,7 @@
               "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js",
               "node_modules/prismjs/components/prism-bash.min.js",
               "node_modules/prismjs/components/prism-c.min.js",
+              "node_modules/prismjs/components/prism-clike.min.js",
               "node_modules/prismjs/components/prism-cpp.min.js",
               "node_modules/prismjs/components/prism-diff.min.js",
               "node_modules/prismjs/components/prism-javascript.min.js",
@@ -60,7 +61,8 @@
               "node_modules/prismjs/components/prism-python.min.js",
               "node_modules/prismjs/components/prism-typescript.min.js",
               "node_modules/emoji-toolkit/lib/js/joypixels.js",
-              "node_modules/katex/dist/katex.min.js"
+              "node_modules/katex/dist/katex.min.js",
+              "node_modules/mermaid/dist/mermaid.min.js"
             ],
             "allowedCommonJsDependencies": [
               "gumshoejs",

--- a/demo/src/app/plugins/plugins.component.html
+++ b/demo/src/app/plugins/plugins.component.html
@@ -1,6 +1,7 @@
 <app-scrollspy-nav-layout [headings]="headings">
   <h1>Plugins</h1>
 
+  <!-- PLUGINS - Emoji -->
   <section>
     <h2 id="emoji">Emoji plugin</h2>
 
@@ -37,6 +38,7 @@
     </markdown>
   </section>
 
+  <!-- PLUGINS - Line Numbers -->
   <section>
     <h2 id="line-numbers">Line Numbers plugin</h2>
 
@@ -88,18 +90,19 @@
       function root(x, n) &#123;
         try &#123;
           var negate = n % 2 == 1 && x < 0;
-          if(negate)
+          if (negate)
             x = -x;
           var possible = Math.pow(x, 1 / n);
           n = Math.pow(possible, n);
-          if(Math.abs(x - n) < 1 && (x > 0 == n > 0))
+          if (Math.abs(x - n) < 1 && (x > 0 == n > 0))
             return negate ? -possible : possible;
-        } catch(e)&#123; }
+        } catch (e) &#123; }
       }
       ```
     </markdown>
   </section>
 
+  <!-- PLUGINS - Line Highlight -->
   <section>
     <h2 id="line-highlight">Line Highlight plugin</h2>
 
@@ -136,71 +139,16 @@
       function root(x, n) &#123;
         try &#123;
           var negate = n % 2 == 1 && x < 0;
-          if(negate)
+          if (negate)
             x = -x;
           var possible = Math.pow(x, 1 / n);
           n = Math.pow(possible, n);
-          if(Math.abs(x - n) < 1 && (x > 0 == n > 0))
+          if (Math.abs(x - n) < 1 && (x > 0 == n > 0))
             return negate ? -possible : possible;
-        } catch(e)&#123; }
+        } catch (e) &#123; }
       }
       ```
     </markdown>
-  </section>
-
-  <section>
-    <h2 id="katex">KaTeX plugin</h2>
-
-    <markdown ngPreserveWhitespaces>
-      #### KaTeX files to include
-      ```javascript
-      node_modules/katex/dist/katex.min.css
-      node_modules/katex/dist/katex.min.js
-      ```
-      #### Directive
-      `katex` - activate KaTeX plugin
-      #### Attributes
-      `katexOptions` - math rendering [options](https://katex.org/docs/options.html)<br>
-      ### Example
-    </markdown>
-
-    <markdown>
-      You can render KaTex expression by adding `katex` directive on the `markdown` component/directive.
-    </markdown>
-
-    <markdown [src]="'app/plugins/remote/katex.html'"></markdown>
-
-    <markdown>
-      The example below illustrate `katex` directive in action.
-    </markdown>
-
-    <div fxLayout="column" fxLayout.gt-sm="row" fxLayoutGap="16px">
-      <mat-form-field appearance="fill" color="accent" fxFlex.gt-sm="calc(50% - 8px)">
-        <textarea matInput [(ngModel)]="katexMarkdown"></textarea>
-      </mat-form-field>
-
-      <markdown [data]="katexMarkdown" katex fxFlex.gt-sm="calc(50% - 8px)"></markdown>
-    </div>
-
-    <markdown ngPreserveWhitespaces>
-      Optionally, you can specify math rendering [options](https://katex.org/docs/options.html) using `katexOptions` property.
-
-      **example.component.ts**
-      ```typescript
-      import &#123; KatexOptions } from 'ngx-markdown';
-
-      public options: KatexOptions = &#123;
-        displayMode: true,
-        throwOnError: false,
-        errorColor: '#cc0000',
-        ...
-      };
-      ```
-
-      **example.component.html**
-    </markdown>
-
-    <markdown [src]="'app/plugins/remote/katex-options.html'"></markdown>
   </section>
 
   <!-- PLUGINS - CommandLine -->
@@ -308,6 +256,121 @@
       [prompt]="'PS C:\Users\Chris>'"
       [filterOutput]="'(out)'"
       [src]="'app/plugins/remote/windows-powershell-with-filter-output.powershell'">
+    </markdown>
+  </section>
+
+  <!-- PLUGINS - Katex -->
+  <section>
+    <h2 id="katex">KaTeX plugin</h2>
+
+    <markdown ngPreserveWhitespaces>
+      #### KaTeX files to include
+      ```javascript
+      node_modules/katex/dist/katex.min.css
+      node_modules/katex/dist/katex.min.js
+      ```
+      #### Directive
+      `katex` - activate KaTeX plugin
+      #### Attributes
+      `katexOptions` - math rendering [options](https://katex.org/docs/options.html)<br>
+      ### Example
+    </markdown>
+
+    <markdown>
+      You can render KaTex expression by adding `katex` directive on the `markdown` component/directive.
+    </markdown>
+
+    <markdown [src]="'app/plugins/remote/katex.html'"></markdown>
+
+    <markdown>
+      The example below illustrate `katex` directive in action.
+    </markdown>
+
+    <div fxLayout="column" fxLayout.gt-sm="row" fxLayoutGap="16px">
+      <mat-form-field appearance="fill" color="accent" fxFlex.gt-sm="calc(50% - 8px)">
+        <textarea matInput [(ngModel)]="katexMarkdown"></textarea>
+      </mat-form-field>
+
+      <markdown [data]="katexMarkdown" katex fxFlex.gt-sm="calc(50% - 8px)"></markdown>
+    </div>
+
+    <markdown ngPreserveWhitespaces>
+      Optionally, you can specify math rendering [options](https://katex.org/docs/options.html) using `katexOptions` property.
+
+      **example.component.ts**
+      ```typescript
+      import &#123; KatexOptions } from 'ngx-markdown';
+
+      public options: KatexOptions = &#123;
+        displayMode: true,
+        throwOnError: false,
+        errorColor: '#cc0000',
+        ...
+      };
+      ```
+
+      **example.component.html**
+    </markdown>
+
+    <markdown [src]="'app/plugins/remote/katex-options.html'"></markdown>
+  </section>
+
+  <!-- PLUGINS - Mermaid -->
+  <section>
+    <h2 id="mermaid">Mermaid plugin</h2>
+
+    <markdown ngPreserveWhitespaces>
+      #### Mermaid file to include
+      ```javascript
+      node_modules/mermaid/dist/mermaid.min.js
+      ```
+      #### Directive
+      `mermaid` - activate mermaid plugin
+      #### Attributes
+      `mermaidOptions` - mermaid [configuration options](https://mermaid-js.github.io/mermaid/#/Setup?id=configuration)<br>
+      ### Example
+    </markdown>
+
+    <markdown>
+      Using `mermaid` input property on `markdown` component or directive (this is not available when using pipe or service) allows you to use [mermaid](https://mermaid-js.github.io/) syntax to generate diagrams and flowcharts.
+    </markdown>
+
+    <markdown [src]="'app/plugins/remote/mermaid.html'"></markdown>
+
+    <markdown>
+      The example below illustrate `mermaid` directive in action.
+    </markdown>
+
+    <div fxLayout="column" fxLayout.gt-sm="row" fxLayoutGap="16px">
+      <mat-form-field appearance="fill" color="accent" fxFlex.gt-sm="calc(50% - 8px)">
+        <textarea matInput [(ngModel)]="mermaidMarkdown"></textarea>
+      </mat-form-field>
+
+      <markdown [data]="mermaidMarkdown" mermaid [mermaidOptions]="mermaidOptions" fxFlex.gt-sm="calc(50% - 8px)"></markdown>
+    </div>
+
+    <markdown ngPreserveWhitespaces>
+      Optionally, you can specify mermaid [configuration options](https://mermaid-js.github.io/mermaid/#/Setup?id=configuration) using `mermaidOptions` property.
+
+      **example.component.ts**
+      ```typescript
+      import &#123; MermaidAPI } from 'ngx-markdown';
+
+      public options: MermaidAPI.Config = &#123;
+        fontFamily: '"trebuchet ms", verdana, arial, sans-serif',
+        logLevel: MermaidAPI.LogLevel.Info,
+        theme: MermaidAPI.Theme.Dark,
+        ...
+      };
+      ```
+
+      **example.component.html**
+    </markdown>
+
+    <markdown [src]="'app/plugins/remote/mermaid-options.html'"></markdown>
+
+    <markdown emoji>
+      > :blue_book: You can refer to this [Mermaid](https://mermaid-js.github.io/) documentation for complete usage syntax.
     </markdown>
   </section>
 </app-scrollspy-nav-layout>

--- a/demo/src/app/plugins/plugins.component.ts
+++ b/demo/src/app/plugins/plugins.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, ElementRef, OnInit } from '@angular/core';
+import { MermaidAPI } from 'ngx-markdown';
 
 @Component({
   selector: 'app-plugins',
@@ -18,6 +19,20 @@ f(x) = \\int_{-\\infty}^\\infty \\hat f(\\xi) e^{2 \\pi i \\xi x} d\\xi
 \`\`\`
 
 $f(x) = \\int_{-\\infty}^\\infty \\hat f(\\xi) e^{2 \\pi i \\xi x} d\\xi$`;
+
+  mermaidMarkdown =
+`\`\`\`mermaid
+graph TD;
+  A-->B;
+  A-->C;
+  B-->D;
+  C-->D;
+\`\`\``;
+
+  mermaidOptions: MermaidAPI.Config = {
+    fontFamily: 'inherit',
+    theme: MermaidAPI.Theme.Dark,
+  };
 
   headings: Element[] | undefined;
 

--- a/demo/src/app/plugins/remote/mermaid-options.html
+++ b/demo/src/app/plugins/remote/mermaid-options.html
@@ -1,5 +1,5 @@
 <markdown
-  katex
-  [katexOptions]="options"
+  mermaid
+  [mermaidOptions]="options"
   [src]="'path/to/file.md'">
 </markdown>

--- a/demo/src/app/plugins/remote/mermaid.html
+++ b/demo/src/app/plugins/remote/mermaid.html
@@ -1,5 +1,4 @@
 <markdown
-  katex
-  [katexOptions]="options"
+  mermaid
   [src]="'path/to/file.md'">
 </markdown>

--- a/demo/src/prism.ts
+++ b/demo/src/prism.ts
@@ -6,56 +6,66 @@
  * https://prismjs.com/extending.html
  */
 
-declare let Prism: any;
+ declare let Prism: any;
 
-Prism.languages.typescript = Prism.languages.extend('typescript', {
+ Prism.languages.typescript = Prism.languages.extend('typescript', {
 
-  'class-name': [
-    // existing pattern
-    Prism.languages.typescript['class-name'],
+   'class-name': [
+     // existing pattern
+     Prism.languages.typescript['class-name'],
 
-    // constructor(private foo:Foo, bar: Bar) { }
-    // function foo(): Bar {}
-    // const foo = (): Bar => {};
-    // const foo = (): void => {};
-    // foo: Bar = {};
-    {
-      pattern: /(:)([^,()={][A-Z]{1}[^,()={]+)/,
-      lookbehind: true,
-      inside: Prism.languages.typescript,
-    },
+     // constructor(private foo:Foo, bar: Bar) { }
+     // function foo(): Bar {}
+     // const foo = (): Bar => {};
+     // const foo = (): void => {};
+     // foo: Bar = {};
+     {
+       pattern: /(:)([^,()={][A-Z]{1}[^,()={]+)/,
+       lookbehind: true,
+       inside: Prism.languages.typescript,
+     },
 
-    // new Foo();
-    // new Foo.Bar();
-    {
-      pattern: /\b(new\s.*\.|new\s)([^(]+)/,
-      lookbehind: true,
-    },
+     // new Foo();
+     // new Foo.Bar();
+     {
+       pattern: /\b(new\s.*\.|new\s)([^(]+)/,
+       lookbehind: true,
+     },
 
-    // import { foo, bar } from 'baz';
-    {
-      pattern: /(import\s*{)\s*([^}]*)/,
-      lookbehind: true,
-      inside: {
-        'import-member': /([^,]+)/,
-        punctuation: /(,)/,
-      },
-    },
+     // import { foo, bar } from 'baz';
+     {
+       pattern: /(import\s*{)\s*([^}]*)/,
+       lookbehind: true,
+       inside: {
+         'import-member': /([^,]+)/,
+         punctuation: /(,)/,
+       },
+     },
 
-    // TODO: not correctly highlighted
-    // - `Baz` in `export class Foo implements Bar, Baz`
-    // - `void` in `func: (foo: string) => void = (foo) => {};`
-    // - `Foo` in `Foo.bar()` when Foo is a class
-  ],
+     // TODO: not correctly highlighted
+     // - `Baz` in `export class Foo implements Bar, Baz`
+     // - `void` in `func: (foo: string) => void = (foo) => {};`
+     // - `Foo` in `Foo.bar()` when Foo is a class
+   ],
 
-  function: [
-    // existing pattern
-    Prism.languages.typescript.function,
+   function: [
+     // existing pattern
+     Prism.languages.typescript.function,
 
-    // foo: () => Bar;
-    {
-      pattern: /\b\S+\s*[=]\s*\(.*\).*/,
-      inside: Prism.languages.typescript,
-    },
-  ],
-});
+     // foo: () => Bar;
+     {
+       pattern: /\b\S+\s*[=]\s*\(.*\).*/,
+       inside: Prism.languages.typescript,
+     },
+   ],
+
+   keyword: [
+     // existing pattern
+     ...Prism.languages.typescript.keyword,
+
+     // constructor()
+     /\b(?:constructor)\b/,
+   ],
+ });
+
+ Prism.languages.ts = Prism.languages.typescript;

--- a/demo/src/scss/prism-theme.scss
+++ b/demo/src/scss/prism-theme.scss
@@ -3,143 +3,146 @@
  * @author Visual Studio Code
  */
 
- code[class*="language-"],
- pre[class*="language-"] {
-   color: #9CDCFE;
-   background: none;
-   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-   text-align: left;
-   white-space: pre;
-   word-spacing: normal;
-   word-break: normal;
-   word-wrap: normal;
-   line-height: 1.5;
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #9CDCFE;
+  background: none;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
 
-   -moz-tab-size: 4;
-   -o-tab-size: 4;
-   tab-size: 4;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
 
-   -webkit-hyphens: none;
-   -moz-hyphens: none;
-   -ms-hyphens: none;
-   hyphens: none;
- }
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
 
- /* Code blocks */
- pre[class*="language-"] {
-   padding: 1em;
-   margin: .5em 0;
-   overflow: auto;
- }
+/* Code blocks */
 
- :not(pre) > code[class*="language-"],
- pre[class*="language-"] {
-   border-radius: 4px;
-   background: #1E1E1E;
-   font-size: 14px;
- }
+pre[class*="language-"] {
+  padding: 1em;
+  margin: .5em 0;
+  overflow: auto;
+}
 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-   padding: .1em;
-   border-radius: .3em;
-   white-space: normal;
- }
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  border-radius: 4px;
+  background: #1E1E1E;
+  font-size: 14px;
+}
 
- .token.comment,
- .token.block-comment,
- .token.prolog,
- .token.doctype,
- .token.cdata {
-   color: #6A9955;
- }
+/* Inline code */
 
- .token.punctuation {
-   color: #CCC;
- }
+:not(pre) > code[class*="language-"] {
+  padding: .1em;
+  border-radius: .3em;
+  white-space: normal;
+}
 
- .token.tag,
- .token.namespace,
- .token.deleted {
-   color: #569CD6;
- }
+.token.comment,
+.token.block-comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #6A9955;
+}
 
- .token.attr-name {
-   color: #9CDCFE;
- }
+.token.punctuation {
+  color: #CCC;
+}
 
- .token.function-name {
-   color: #6196cc;
- }
+.token.tag,
+.token.namespace,
+.token.deleted {
+  color: #569CD6;
+}
 
- .token.boolean {
-   color: #569CD6;
- }
+.token.attr-name {
+  color: #9CDCFE;
+}
 
- .token.number {
-   color: #B5CEA8;
- }
+.token.function-name {
+  color: #6196cc;
+}
 
- .token.function {
-   color: #DCDCAA;
- }
+.token.boolean {
+  color: #569CD6;
+}
 
- .token.property,
- .token.constant,
- .token.symbol {
-   color: #51b6c4;
- }
+.token.number {
+  color: #B5CEA8;
+}
 
- .token.builtin,
- .token.class-name {
-   color: #4EC9B0;
- }
+.token.function {
+  color: #DCDCAA;
+}
 
- .token.selector,
- .token.important,
- .token.atrule,
- .token.keyword {
-   color: #C586C0;
- }
+.token.property,
+.token.constant,
+.token.symbol {
+  color: #51b6c4;
+}
 
- .token.string,
- .token.char,
- .token.attr-value,
- .token.variable {
-   color: #CE9169;
-  }
+.token.builtin,
+.token.class-name {
+  color: #4EC9B0;
+}
 
-  .token.regex {
-    color: #d16969;
-  }
+.token.selector,
+.token.important,
+.token.atrule,
+.token.keyword {
+  color: #C586C0;
+}
 
- .token.operator {
-   color: #D4D4D4;
- }
+.token.string,
+.token.char,
+.token.attr-value,
+.token.variable {
+  color: #CE9169;
+}
 
- .token.entity,
- .token.url {
-   color: #67cdcc;
- }
+.token.regex {
+  color: #d16969;
+}
 
- .token.important,
- .token.bold {
-   font-weight: bold;
- }
+.token.operator {
+  color: #D4D4D4;
+}
 
- .token.italic {
-   font-style: italic;
- }
+.token.entity,
+.token.url {
+  color: #67cdcc;
+}
 
- .token.entity {
-   cursor: help;
- }
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
 
- .token.inserted {
-   color: #8fce00;
- }
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+.token.inserted {
+  color: #8fce00;
+}
 
 /* Html */
+
 .language-html :not(.token) {
   color: #d4d4d4;
 }
@@ -148,47 +151,52 @@
   color: #808080;
 }
 
- /* TypeScript */
- .language-typescript .language-javascript {
-   color: #9CDCFE;
- }
+/* TypeScript, Javascript */
 
- .language-typescript .language-javascript .token.string {
-   color: #CE9169;
- }
-
- .language-typescript .language-javascript .token.punctuation {
-   color: #3F9CD6;
- }
-
- .language-typescript .language-javascript .script-punctuation + .token.punctuation + .token.punctuation {
-   color: #D4D4D4;
- }
-
- .language-typescript .language-javascript .script-punctuation + .token.punctuation + .token.punctuation ~ .token.punctuation {
-   color: #D4D4D4;
- }
-
- .language-typescript .language-javascript .script-punctuation + .token.punctuation + .token.punctuation ~ .token.punctuation + .token.punctuation {
-   color: #3F9CD6;
- }
-
-.language-typescript .keyword-class,
-.language-typescript .keyword-const,
-.language-typescript .keyword-constructor,
-.language-typescript .keyword-function,
-.language-typescript .keyword-implements,
-.language-typescript .keyword-new,
-.language-typescript .keyword-private,
-.language-typescript .keyword-public,
-.language-typescript .keyword-this {
-  color: #569CD6;
-}
-
-.language-typescript .keyword-void {
-  color: #4EC9B0;
-}
-
-.language-typescript .import-member {
+.language-ts,
+.language-typescript,
+.language-js,
+.language-javascript {
   color: #9CDCFE;
+
+  .token.string {
+    color: #CE9169;
+  }
+
+  .token.punctuation {
+    color: #D4D4D4;
+  }
+
+  .script-punctuation+.token.punctuation+.token.punctuation {
+    color: #D4D4D4;
+  }
+
+  .script-punctuation+.token.punctuation+.token.punctuation~.token.punctuation {
+    color: #D4D4D4;
+  }
+
+  .script-punctuation+.token.punctuation+.token.punctuation~.token.punctuation+.token.punctuation {
+    color: #3F9CD6;
+  }
+
+  .keyword-class,
+  .keyword-const,
+  .keyword-constructor,
+  .keyword-function,
+  .keyword-implements,
+  .keyword-new,
+  .keyword-private,
+  .keyword-public,
+  .keyword-readonly,
+  .keyword-this {
+    color: #569CD6;
+  }
+
+  .keyword-void {
+    color: #4EC9B0;
+  }
+
+  .import-member {
+    color: #9CDCFE;
+  }
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -29,6 +29,7 @@
     "emoji-toolkit": "^6.6.0",
     "katex": "^0.15.1",
     "marked": "^4.0.10",
+    "mermaid": "^9.0.1",
     "prismjs": "^1.25.0",
     "tslib": "^2.3.0"
   },

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -6,4 +6,5 @@ export * from './markdown.pipe';
 export * from './markdown.service';
 export * from './marked-options';
 export * from './marked-renderer';
+export * from './mermaid-options';
 export * from './prism-plugin';

--- a/lib/src/markdown.component.spec.ts
+++ b/lib/src/markdown.component.spec.ts
@@ -1,25 +1,26 @@
 import { ElementRef } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { first } from 'rxjs/operators';
 
 import { KatexOptions } from './katex-options';
 import { MarkdownComponent } from './markdown.component';
 import { MarkdownModule } from './markdown.module';
-import { MarkdownService } from './markdown.service';
+import { MarkdownService, ParseOptions } from './markdown.service';
+import { MermaidAPI } from './mermaid-options';
 
 describe('MarkdownComponent', () => {
   let fixture: ComponentFixture<MarkdownComponent>;
   let component: MarkdownComponent;
   let markdownService: MarkdownService;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         MarkdownModule.forRoot(),
       ],
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     markdownService = TestBed.inject(MarkdownService);
@@ -60,7 +61,7 @@ describe('MarkdownComponent', () => {
 
   describe('src', () => {
 
-    it('should call render with retreived content when set', waitForAsync(() => {
+    it('should call render with retreived content when set', () => {
 
       const mockSrc = './src-example/file.md';
       const mockContent = 'source-content';
@@ -74,7 +75,7 @@ describe('MarkdownComponent', () => {
 
       expect(markdownService.getSource).toHaveBeenCalledWith(mockSrc);
       expect(component.render).toHaveBeenCalledWith(mockContent);
-    }));
+    });
 
     it('should return value correctly when get', () => {
 
@@ -173,71 +174,38 @@ describe('MarkdownComponent', () => {
 
   describe('render', () => {
 
-    it('should set innerHTML with compiled/decoded html markdown when decodeHtml is true', () => {
+    it('should parse markdown through MarkdownService', () => {
 
       const raw = '### Raw';
-      const decoded = '<h3>Compiled</h3>';
+      const katexOptions: KatexOptions = { displayMode: true };
 
-      spyOn(markdownService, 'compile').and.callFake((markdown: string, decodeHtml: boolean, emojify: boolean) => {
-        return decodeHtml ? decoded : '';
+      spyOn(markdownService, 'parse');
+
+      component.emoji = false;
+      component.katex = true;
+      component.katexOptions = katexOptions;
+      component.mermaid = false;
+      component.render(raw, true);
+
+      expect(markdownService.parse).toHaveBeenCalledWith(raw, {
+        decodeHtml: true,
+        emoji: false,
+        katex: true,
+        katexOptions: katexOptions,
+        mermaid: false,
       });
+    });
+
+    it('should set innerHTML with parsed markdown', () => {
+
+      const raw = '### Raw';
+      const parsed = '<h3>Compiled</h3>';
+
+      spyOn(markdownService, 'parse').and.returnValue(parsed);
 
       component.render(raw, true);
 
-      expect(markdownService.compile).toHaveBeenCalledWith(raw, true, false);
-      expect(component.element.nativeElement.innerHTML).toBe(decoded);
-    });
-
-    it('should set innerHTML with compiled/undecoded html markdown when decodeHtml is omitted/false/null/undefined', () => {
-
-      const raw = '### Raw';
-      const undecoded = '<h3>Compiled-Undecoded</h3>';
-
-      spyOn(markdownService, 'compile').and.callFake((markdown: string, decodeHtml: boolean, emojify: boolean) => {
-        return decodeHtml ? '' : undecoded;
-      });
-
-      component.render(raw);
-
-      expect(markdownService.compile).toHaveBeenCalledWith(raw, false, false);
-      expect(component.element.nativeElement.innerHTML).toBe(undecoded);
-
-      component.render(raw, false);
-
-      expect(markdownService.compile).toHaveBeenCalledWith(raw, false, false);
-      expect(component.element.nativeElement.innerHTML).toBe(undecoded);
-
-      component.render(raw, null!);
-
-      expect(markdownService.compile).toHaveBeenCalledWith(raw, false, false);
-      expect(component.element.nativeElement.innerHTML).toBe(undecoded);
-
-      component.render(raw, undefined);
-
-      expect(markdownService.compile).toHaveBeenCalledWith(raw, false, false);
-      expect(component.element.nativeElement.innerHTML).toBe(undecoded);
-    });
-
-    it('should set innerHTML with compiled/decoded html markdown', () => {
-
-      const raw = '### Raw';
-      const compiled = '<h3>Compiled</h3>';
-
-      spyOn(markdownService, 'compile').and.returnValue(compiled);
-
-      component.render(raw);
-
-      expect(markdownService.compile).toHaveBeenCalledWith(raw, false, false);
-      expect(component.element.nativeElement.innerHTML).toBe(compiled);
-    });
-
-    it('should apply highlight', () => {
-
-      spyOn(markdownService, 'highlight');
-
-      component.render('### Raw');
-
-      expect(markdownService.highlight).toHaveBeenCalledWith(component.element.nativeElement);
+      expect(component.element.nativeElement.innerHTML).toBe(parsed);
     });
 
     it('should handle commandline plugin correctly', () => {
@@ -317,53 +285,66 @@ describe('MarkdownComponent', () => {
       const raw = 'I :heart: ngx-markdown';
       const emojified = 'I ❤️ ngx-markdown';
 
-      spyOn(markdownService, 'compile').and.callFake((markdown: string, decodeHtml: boolean, emojify: boolean) => {
-        return emojify ? emojified : '';
+      spyOn(markdownService, 'parse').and.callFake((markdown: string, { emoji }: ParseOptions) => {
+        return emoji ? emojified : '';
       });
 
       component.emoji = true;
       component.render(raw);
 
-      expect(markdownService.compile).toHaveBeenCalledWith(raw, false, true);
+      expect(markdownService.parse).toHaveBeenCalledWith(raw, {
+        decodeHtml: false,
+        emoji: true,
+        katex: false,
+        katexOptions: undefined,
+        mermaid: false,
+      });
       expect(component.element.nativeElement.innerHTML).toBe(emojified);
     });
 
-    it('should apply katex plugin correctly', () => {
+    it('should render html element through MarkdownService', () => {
+      const raw = '### Raw';
+      const parsed = '<h3>Compiled</h3>';
+      const mermaidOptions: MermaidAPI.Config = { darkMode: true };
 
-      const markdown = '$E=mc^2$';
-      const katexOptions: KatexOptions = { errorColor: '#ff00dd', throwOnError: true };
-      const compiled = '<p>$E=mc^2$</p>';
+      spyOn(markdownService, 'parse').and.returnValue(parsed);
+      spyOn(markdownService, 'render');
 
-      spyOn(markdownService, 'compile').and.returnValue(compiled);
-      spyOn(markdownService, 'renderKatex');
+      component.mermaid = true;
+      component.mermaidOptions = mermaidOptions;
+      component.render(raw);
 
-      component.katex = true;
-      component.katexOptions = katexOptions;
-      component.render(markdown);
+      expect(markdownService.parse).toHaveBeenCalledWith(raw, {
+        decodeHtml: false,
+        emoji: false,
+        katex: false,
+        katexOptions: undefined,
+        mermaid: true,
+      });
 
-      expect(markdownService.renderKatex).toHaveBeenCalledWith(compiled, katexOptions);
+      expect(markdownService.render).toHaveBeenCalledWith(component.element.nativeElement, {
+        mermaid: true,
+        mermaidOptions: mermaidOptions,
+      });
     });
 
-    it('should emit `ready` when done parsing', waitForAsync(() => {
+    it('should emit `ready` when parsing and rendering is done', () => {
 
       const markdown = '# Markdown';
-      const compiled = '<h1 id="markdown">Markdown</h1>';
+      const parsed = '<h1 id="markdown">Markdown</h1>';
 
-      spyOn(markdownService, 'compile').and.returnValue(compiled);
-      spyOn(markdownService, 'renderKatex').and.returnValue(compiled);
-      spyOn(markdownService, 'highlight');
+      spyOn(markdownService, 'parse').and.returnValue(parsed);
+      spyOn(markdownService, 'render');
 
       component.ready
         .pipe(first())
         .subscribe(() => {
-          expect(markdownService.compile).toHaveBeenCalled();
-          expect(markdownService.renderKatex).toHaveBeenCalled();
-          expect(markdownService.highlight).toHaveBeenCalled();
-          expect(component.element.nativeElement.innerHTML).toBe(compiled);
+          expect(markdownService.parse).toHaveBeenCalled();
+          expect(component.element.nativeElement.innerHTML).toBe(parsed);
+          expect(markdownService.render).toHaveBeenCalled();
         });
 
-      component.katex = true;
       component.render(markdown);
-    }));
+    });
   });
 });

--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, O
 
 import { KatexOptions } from './katex-options';
 import { MarkdownService } from './markdown.service';
+import { MermaidAPI } from './mermaid-options';
 import { PrismPlugin } from './prism-plugin';
 
 @Component({
@@ -13,6 +14,7 @@ export class MarkdownComponent implements OnChanges, AfterViewInit {
 
   protected static ngAcceptInputType_emoji: boolean | '';
   protected static ngAcceptInputType_katex: boolean | '';
+  protected static ngAcceptInputType_mermaid: boolean | '';
   protected static ngAcceptInputType_lineHighlight: boolean | '';
   protected static ngAcceptInputType_lineNumbers: boolean | '';
   protected static ngAcceptInputType_commandLine: boolean | '';
@@ -30,6 +32,12 @@ export class MarkdownComponent implements OnChanges, AfterViewInit {
   get katex(): boolean { return this._katex; }
   set katex(value: boolean) { this._katex = this.coerceBooleanProperty(value); }
   @Input() katexOptions: KatexOptions | undefined;
+
+  // Plugin - mermaid
+  @Input()
+  get mermaid(): boolean { return this._mermaid; }
+  set mermaid(value: boolean) { this._mermaid = this.coerceBooleanProperty(value); }
+  @Input() mermaidOptions: MermaidAPI.Config | undefined;
 
   // Plugin - lineHighlight
   @Input()
@@ -62,6 +70,7 @@ export class MarkdownComponent implements OnChanges, AfterViewInit {
   private _commandLine = false;
   private _emoji = false;
   private _katex = false;
+  private _mermaid = false;
   private _lineHighlight = false;
   private _lineNumbers = false;
 
@@ -88,11 +97,23 @@ export class MarkdownComponent implements OnChanges, AfterViewInit {
   }
 
   render(markdown: string, decodeHtml = false): void {
-    let compiled = this.markdownService.compile(markdown, decodeHtml, this.emoji);
-    compiled = this.katex ? this.markdownService.renderKatex(compiled, this.katexOptions) : compiled;
-    this.element.nativeElement.innerHTML = compiled;
+    const parsed = this.markdownService.parse(markdown, {
+      decodeHtml,
+      emoji: this.emoji,
+      katex: this.katex,
+      katexOptions: this.katexOptions,
+      mermaid: this.mermaid,
+    });
+
+    this.element.nativeElement.innerHTML = parsed;
+
     this.handlePlugins();
-    this.markdownService.highlight(this.element.nativeElement);
+
+    this.markdownService.render(this.element.nativeElement, {
+      mermaid: this.mermaid,
+      mermaidOptions: this.mermaidOptions,
+    });
+
     this.ready.emit();
   }
 

--- a/lib/src/markdown.module.spec.ts
+++ b/lib/src/markdown.module.spec.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { Component, SecurityContext } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { MarkdownModule } from './markdown.module';
 import { errorSrcWithoutHttpClient, SECURITY_CONTEXT } from './markdown.service';
@@ -202,15 +202,15 @@ describe('MarkdownModule', () => {
 
   describe('without HttpClient', () => {
 
-    beforeEach(waitForAsync(() => {
-      void TestBed.configureTestingModule({
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
         imports: [
           CommonModule,
           MarkdownModule.forRoot(),
         ],
         declarations: [HostComponent],
       }).compileComponents();
-    }));
+    });
 
     it('should render the markdown if not passing src attribute', () => {
 

--- a/lib/src/markdown.pipe.spec.ts
+++ b/lib/src/markdown.pipe.spec.ts
@@ -52,19 +52,19 @@ describe('MarkdownPipe', () => {
     });
   });
 
-  it('should apply synthax highlight when zone is stable', fakeAsync(() => {
+  it('should render element through MarkdownService when zone is stable', fakeAsync(() => {
 
     const markdown = '# Markdown';
 
-    spyOn(markdownService, 'highlight');
+    spyOn(markdownService, 'render');
 
     pipe.transform(markdown);
 
-    expect(markdownService.highlight).not.toHaveBeenCalled();
+    expect(markdownService.render).not.toHaveBeenCalled();
 
     zone.onStable.emit(null);
 
-    expect(markdownService.highlight).toHaveBeenCalledWith(elementRef.nativeElement);
+    expect(markdownService.render).toHaveBeenCalledWith(elementRef.nativeElement);
   }));
 
   it('should return compiled markdown', () => {
@@ -73,12 +73,12 @@ describe('MarkdownPipe', () => {
     const mockCompiled = 'compiled-x';
     const mockBypassSecurity = 'bypass-x';
 
-    spyOn(markdownService, 'compile').and.returnValue(mockCompiled);
+    spyOn(markdownService, 'parse').and.returnValue(mockCompiled);
     spyOn(domSanitizer, 'bypassSecurityTrustHtml').and.returnValue(mockBypassSecurity);
 
     const result = pipe.transform(markdown);
 
-    expect(markdownService.compile).toHaveBeenCalledWith(markdown);
+    expect(markdownService.parse).toHaveBeenCalledWith(markdown);
     expect(domSanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(mockCompiled);
     expect(result).toBe(mockBypassSecurity);
   });

--- a/lib/src/markdown.pipe.ts
+++ b/lib/src/markdown.pipe.ts
@@ -26,11 +26,11 @@ export class MarkdownPipe implements PipeTransform {
       return value;
     }
 
-    const markdown = this.markdownService.compile(value);
+    const markdown = this.markdownService.parse(value);
 
     this.zone.onStable
       .pipe(first())
-      .subscribe(() => this.markdownService.highlight(this.elementRef.nativeElement));
+      .subscribe(() => this.markdownService.render(this.elementRef.nativeElement));
 
     return this.domSanitizer.bypassSecurityTrustHtml(markdown);
   }

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -6,12 +6,14 @@ import { marked } from 'marked';
 
 import { KatexOptions } from './katex-options';
 import { MarkdownModule } from './markdown.module';
-import { errorJoyPixelsNotLoaded, errorKatexNotLoaded, MarkdownService, SECURITY_CONTEXT } from './markdown.service';
+import { errorJoyPixelsNotLoaded, errorKatexNotLoaded, errorMermaidNotLoaded, MarkdownService, SECURITY_CONTEXT } from './markdown.service';
+import { MermaidAPI } from './mermaid-options';
 
 declare let global: any;
 declare let Prism: any;
 declare let joypixels: any;
 declare let katex: any;
+declare let mermaid: any;
 
 describe('MarkdowService', () => {
   let domSanitizer: DomSanitizer;
@@ -20,7 +22,7 @@ describe('MarkdowService', () => {
 
   describe('with SecurityContext.HTML', () => {
 
-    describe('compile', () => {
+    describe('parse', () => {
 
       beforeEach(() => {
         TestBed.configureTestingModule({
@@ -28,9 +30,7 @@ describe('MarkdowService', () => {
             MarkdownModule.forRoot({ sanitize: SecurityContext.HTML }),
           ],
         });
-      });
 
-      beforeEach(() => {
         domSanitizer = TestBed.inject(DomSanitizer);
         markdownService = TestBed.inject(MarkdownService);
       });
@@ -43,8 +43,8 @@ describe('MarkdowService', () => {
         const sanitized = domSanitizer.sanitize(securityContext, marked(mockRaw));
         const unsanitized = marked(mockRaw);
 
-        expect(markdownService.compile(mockRaw, false)).toBe(sanitized!);
-        expect(markdownService.compile(mockRaw, false)).not.toBe(unsanitized);
+        expect(markdownService.parse(mockRaw, { decodeHtml: false })).toBe(sanitized!);
+        expect(markdownService.parse(mockRaw, { decodeHtml: false })).not.toBe(unsanitized);
       });
     });
   });
@@ -59,9 +59,7 @@ describe('MarkdowService', () => {
           MarkdownModule.forRoot({ sanitize: SecurityContext.NONE }),
         ],
       });
-    });
 
-    beforeEach(() => {
       http = TestBed.inject(HttpTestingController);
       markdownService = TestBed.inject(MarkdownService);
     });
@@ -108,20 +106,20 @@ describe('MarkdowService', () => {
       });
     });
 
-    describe('compile', () => {
+    describe('parse', () => {
 
       it('should return parsed markdown correctly', () => {
 
         const mockRaw = '### Markdown-x';
 
-        expect(markdownService.compile(mockRaw)).toBe(marked(mockRaw));
+        expect(markdownService.parse(mockRaw)).toBe(marked(mockRaw));
       });
 
       it('should return empty string when raw is null/undefined/empty', () => {
 
-        expect(markdownService.compile(null!)).toBe('');
-        expect(markdownService.compile(undefined!)).toBe('');
-        expect(markdownService.compile('')).toBe('');
+        expect(markdownService.parse(null!)).toBe('');
+        expect(markdownService.parse(undefined!)).toBe('');
+        expect(markdownService.parse('')).toBe('');
       });
 
       it('should remove leading whitespaces offset while keeping indent', () => {
@@ -138,7 +136,7 @@ describe('MarkdowService', () => {
           '   * sub-list',
         ].join('\n');
 
-        expect(markdownService.compile(mockRaw)).toBe(marked(expected));
+        expect(markdownService.parse(mockRaw)).toBe(marked(expected));
       });
 
       it('should return line with indent correctly', () => {
@@ -160,7 +158,7 @@ describe('MarkdowService', () => {
           'Lorem Ipsum',
         ].join('\n');
 
-        expect(markdownService.compile(mockRaw)).toBe(marked(expected));
+        expect(markdownService.parse(mockRaw)).toBe(marked(expected));
       });
 
       it('should decode HTML correctly when decodeHtml is true ', () => {
@@ -168,7 +166,7 @@ describe('MarkdowService', () => {
         const mockRaw = '&lt;html&gt;';
         const expected = '<html>';
 
-        expect(markdownService.compile(mockRaw, true)).toBe(expected);
+        expect(markdownService.parse(mockRaw, { decodeHtml: true })).toBe(expected);
       });
 
       it('should not decode HTML when decodeHtml is omitted/false/null/undefined', () => {
@@ -176,43 +174,34 @@ describe('MarkdowService', () => {
         const mockRaw = '&lt;html&gt;';
         const expected = '<p>&lt;html&gt;</p>\n';
 
-        expect(markdownService.compile(mockRaw)).toBe(expected);
-        expect(markdownService.compile(mockRaw, false)).toBe(expected);
-        expect(markdownService.compile(mockRaw, null!)).toBe(expected);
-        expect(markdownService.compile(mockRaw, undefined)).toBe(expected);
+        expect(markdownService.parse(mockRaw)).toBe(expected);
+        expect(markdownService.parse(mockRaw, { decodeHtml: false })).toBe(expected);
+        expect(markdownService.parse(mockRaw, { decodeHtml: null! })).toBe(expected);
+        expect(markdownService.parse(mockRaw, { decodeHtml: undefined })).toBe(expected);
       });
 
       it('should not decode HTML when platform is not browser as it uses `document`', () => {
 
         const mockRaw = '&lt;html&gt;';
-        const expected = '<p>&lt;html&gt;</p>\n';
+        const expected = '&lt;html&gt;';
 
         markdownService['platform'] = 'server';
 
-        expect(markdownService.compile(mockRaw, true)).toBe(expected);
+        expect(markdownService.parse(mockRaw, { decodeHtml: true })).toBe(expected);
       });
 
-      it('should not sanitize parsed markdown', () => {
-
-        const mockRaw = '### Markdown-x';
-        const expected = marked(mockRaw);
-
-        expect(markdownService.compile(mockRaw, false)).toBe(expected);
-        expect(markdownService.compile(mockRaw, false)).toBe(expected);
-      });
-
-      it('should throw when emojify is true but emoji-toolkit is not loaded', () => {
+      it('should throw when emoji is true but emoji-toolkit is not loaded', () => {
 
         global['joypixels'] = undefined;
 
-        expect(() => markdownService.compile('I :heart: ngx-markdown', false, true)).toThrowError(errorJoyPixelsNotLoaded);
+        expect(() => markdownService.parse('I :heart: ngx-markdown', { decodeHtml: false, emoji: true })).toThrowError(errorJoyPixelsNotLoaded);
 
         global['joypixels'] = { shortnameToUnicode: undefined };
 
-        expect(() => markdownService.compile('I :heart: ngx-markdown', false, true)).toThrowError(errorJoyPixelsNotLoaded);
+        expect(() => markdownService.parse('I :heart: ngx-markdown', { decodeHtml: false, emoji: true })).toThrowError(errorJoyPixelsNotLoaded);
       });
 
-      it('should call joypixels when emojify is true', () => {
+      it('should call joypixels when emoji is true', () => {
 
         const mockRaw = 'I :heart: ngx-markdown';
         const mockEmojified = 'I ❤️ ngx-markdown';
@@ -221,11 +210,11 @@ describe('MarkdowService', () => {
 
         spyOn(joypixels, 'shortnameToUnicode').and.returnValue(mockEmojified);
 
-        expect(markdownService.compile(mockRaw, false, true)).toEqual(marked(mockEmojified));
+        expect(markdownService.parse(mockRaw, { decodeHtml: false, emoji: true })).toEqual(marked(mockEmojified));
         expect(joypixels.shortnameToUnicode).toHaveBeenCalledWith(mockRaw);
       });
 
-      it('should not call joypixels when emojify is omitted/false/null/undefined', () => {
+      it('should not call joypixels when emoji is omitted/false/null/undefined', () => {
 
         const mockRaw = '### Markdown-x';
 
@@ -234,10 +223,10 @@ describe('MarkdowService', () => {
         spyOn(joypixels, 'shortnameToUnicode');
 
         const useCases = [
-          () => markdownService.compile(mockRaw, false),
-          () => markdownService.compile(mockRaw, false, false),
-          () => markdownService.compile(mockRaw, false, null!),
-          () => markdownService.compile(mockRaw, false, undefined),
+          () => markdownService.parse(mockRaw, { decodeHtml: false }),
+          () => markdownService.parse(mockRaw, { decodeHtml: false, emoji: false }),
+          () => markdownService.parse(mockRaw, { decodeHtml: false, emoji: null! }),
+          () => markdownService.parse(mockRaw, { decodeHtml: false, emoji: undefined }),
         ];
 
         useCases.forEach(func => {
@@ -256,8 +245,266 @@ describe('MarkdowService', () => {
 
         markdownService['platform'] = 'server';
 
-        expect(() => markdownService.compile(mockRaw, false, true)).not.toThrowError();
+        expect(() => markdownService.parse(mockRaw, { decodeHtml: false, emoji: true })).not.toThrowError();
         expect(joypixels.shortnameToUnicode).not.toHaveBeenCalled();
+      });
+
+      it('should call katex when katex is true', () => {
+
+        const mockRaw = '$E=mc^2$';
+        const katexOptions = { displayMode: true };
+
+        global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
+
+        spyOn(katex, 'renderToString');
+
+        markdownService.parse(mockRaw, { katex: true, katexOptions });
+
+        expect(katex.renderToString).toHaveBeenCalledWith(mockRaw.replace(/\$/gm, ''), katexOptions);
+      });
+
+      it('should not call katex when katex is omitted/false/null/undefined', () => {
+
+        const mockRaw = '$E=mc^2$';
+
+        global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
+
+        spyOn(katex, 'renderToString');
+
+        const useCases = [
+          () => markdownService.parse(mockRaw),
+          () => markdownService.parse(mockRaw, { katex: false }),
+          () => markdownService.parse(mockRaw, { katex: null! }),
+          () => markdownService.parse(mockRaw, { katex: undefined }),
+        ];
+
+        useCases.forEach(func => {
+          func();
+          expect(katex.renderToString).not.toHaveBeenCalled();
+        });
+      });
+
+      it('should not call katex or throw when platform is not browser', () => {
+
+        const mockRaw = '$E=mc^2$';
+
+        global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
+
+        spyOn(katex, 'renderToString');
+
+        markdownService['platform'] = 'server';
+
+        expect(() => markdownService.parse(mockRaw, { katex: true })).not.toThrowError();
+        expect(katex.renderToString).not.toHaveBeenCalled();
+      });
+
+      it('should throw when katex is called but not loaded', () => {
+
+        const mockRaw = '$E=mc^2$';
+
+        global['katex'] = undefined;
+
+        expect(() => markdownService.parse(mockRaw, { katex: true })).toThrowError(errorKatexNotLoaded);
+
+        global['katex'] = { renderToString: undefined };
+
+        expect(() => markdownService.parse(mockRaw, { katex: true })).toThrowError(errorKatexNotLoaded);
+      });
+
+      it('should call katex with math expressions', () => {
+
+        global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
+
+        spyOn(katex, 'renderToString');
+
+        const useCases = [
+          { tex: '$E=mc^2$' },
+          { tex: '$x^2 + y^2 = z^2$', options: { displayMode: true } },
+        ];
+
+        useCases.forEach(useCase => {
+          markdownService.parse(useCase.tex, { katex: true, katexOptions: useCase.options });
+          expect(katex.renderToString).toHaveBeenCalledWith(useCase.tex.replace(/\$/gm, ''), useCase.options);
+          katex.renderToString.calls.reset();
+        });
+      });
+
+      it('should not parse markdown when platform is not browser', () => {
+
+        const mockRaw = '### Markdown-x';
+        const expected = mockRaw;
+
+        markdownService['platform'] = 'server';
+
+        expect(() => markdownService.parse(mockRaw)).not.toThrowError();
+        expect(markdownService.parse(mockRaw)).toBe(expected);
+      });
+
+      it('should not sanitize parsed markdown', () => {
+
+        const mockRaw = '### Markdown-x';
+        const expected = marked(mockRaw);
+
+        expect(markdownService.parse(mockRaw, { decodeHtml: false })).toBe(expected);
+      });
+    });
+
+    describe('render', () => {
+      it('should render mermaid with default options when mermaid is true and options are omitted', () => {
+
+        const elementOne = document.createElement('div');
+        elementOne.classList.add('mermaid');
+
+        const elementTwo = document.createElement('div');
+        elementTwo.classList.add('mermaid');
+
+        const container = document.createElement('div');
+        container.append(elementOne);
+        container.append(elementTwo);
+
+        const expected = container.querySelectorAll('.mermaid');
+
+        global['mermaid'] = {
+          initialize: (options: MermaidAPI.Config) => {},
+          init: (nodes: string | Node | NodeList) => {},
+        };
+
+        spyOn(mermaid, 'initialize');
+        spyOn(mermaid, 'init');
+
+        markdownService.render(container, { mermaid: true });
+
+        expect(mermaid.initialize).toHaveBeenCalledWith({ startOnLoad: false });
+        expect(mermaid.init).toHaveBeenCalledWith(expected);
+      });
+
+      it('should render mermaid with provided options when at least one element is found', () => {
+
+        const element = document.createElement('div');
+        element.classList.add('mermaid');
+        element.innerHTML = 'graph TD; A-->B;';
+
+        const container = document.createElement('div');
+        container.append(element);
+
+        const expected = container.querySelectorAll('.mermaid');
+        const mermaidOptions: MermaidAPI.Config = { darkMode: true };
+
+        global['mermaid'] = {
+          initialize: (options: MermaidAPI.Config) => {},
+          init: (nodes: string | Node | NodeList) => {},
+        };
+
+        spyOn(mermaid, 'initialize');
+        spyOn(mermaid, 'init');
+
+        markdownService.render(container, { mermaid: true, mermaidOptions });
+
+        expect(mermaid.initialize).toHaveBeenCalledWith(mermaidOptions);
+        expect(mermaid.init).toHaveBeenCalledWith(expected);
+      });
+
+      it('should not render mermaid when mermaid is omitted/false/null/undefined', () => {
+
+        const element = document.createElement('div');
+        element.classList.add('mermaid');
+
+        const container = document.createElement('div');
+        container.append(element);
+
+        global['mermaid'] = {
+          initialize: (options: MermaidAPI.Config) => {},
+          init: (nodes: string | Node | NodeList) => {},
+        };
+
+        spyOn(mermaid, 'initialize');
+        spyOn(mermaid, 'init');
+
+        const useCases = [
+          () => markdownService.render(container),
+          () => markdownService.render(container, { mermaid: false }),
+          () => markdownService.render(container, { mermaid: null! }),
+          () => markdownService.render(container, { mermaid: undefined }),
+        ];
+
+        useCases.forEach(func => {
+          func();
+          expect(mermaid.initialize).not.toHaveBeenCalled();
+          expect(mermaid.init).not.toHaveBeenCalled();
+        });
+      });
+
+      it('should not render mermaid or throw when platform is not browser', () => {
+
+        const element = document.createElement('div');
+        element.classList.add('mermaid');
+
+        const container = document.createElement('div');
+        container.append(element);
+
+        global['mermaid'] = {
+          initialize: (options: MermaidAPI.Config) => {},
+          init: (nodes: string | Node | NodeList) => {},
+        };
+
+        spyOn(mermaid, 'initialize');
+        spyOn(mermaid, 'init');
+
+        markdownService['platform'] = 'server';
+
+        expect(() => markdownService.render(container, { mermaid: true })).not.toThrowError();
+        expect(mermaid.initialize).not.toHaveBeenCalled();
+        expect(mermaid.init).not.toHaveBeenCalled();
+      });
+
+      it('should throw when mermaid is called but not loaded', () => {
+
+        const element = document.createElement('div');
+        element.classList.add('mermaid');
+
+        const container = document.createElement('div');
+        container.append(element);
+
+        global['mermaid'] = undefined;
+
+        expect(() => markdownService.render(container, { mermaid: true })).toThrowError(errorMermaidNotLoaded);
+
+        global['mermaid'] = { initialize: undefined };
+        global['mermaid'] = { init: undefined };
+
+        expect(() => markdownService.render(container, { mermaid: true })).toThrowError(errorMermaidNotLoaded);
+      });
+
+      it('should not render mermaid when no elements are found', () => {
+
+        const element = document.createElement('div');
+        element.classList.add('not-mermaid');
+
+        const container = document.createElement('div');
+        container.append(element);
+
+        global['mermaid'] = {
+          initialize: (options: MermaidAPI.Config) => {},
+          init: (nodes: string | Node | NodeList) => {},
+        };
+
+        spyOn(mermaid, 'initialize');
+        spyOn(mermaid, 'init');
+
+        expect(() => markdownService.render(container, { mermaid: true })).not.toThrowError();
+        expect(mermaid.initialize).not.toHaveBeenCalled();
+        expect(mermaid.init).not.toHaveBeenCalled();
+      });
+
+      it('should highlight element', () => {
+
+        const element = document.createElement('div');
+
+        spyOn(markdownService, 'highlight');
+
+        markdownService.render(element);
+
+        expect(markdownService.highlight).toHaveBeenCalled();
       });
     });
 
@@ -418,52 +665,6 @@ describe('MarkdowService', () => {
           func();
           expect(Prism.highlightAllUnder).toHaveBeenCalledWith(document);
           Prism.highlightAllUnder.calls.reset();
-        });
-      });
-    });
-
-    describe('renderKatex', () => {
-
-      it('should not call katex or throw when platform is not browser', () => {
-
-        const mockRaw = '$E=mc^2$';
-
-        global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
-
-        spyOn(katex, 'renderToString');
-
-        markdownService['platform'] = 'server';
-
-        expect(() => markdownService.renderKatex(mockRaw)).not.toThrowError();
-        expect(katex.renderToString).not.toHaveBeenCalled();
-      });
-
-      it('should throw when katex is called but not loaded', () => {
-
-        global['katex'] = undefined;
-
-        expect(() => markdownService.renderKatex('$example$')).toThrowError(errorKatexNotLoaded);
-
-        global['katex'] = { renderToString: undefined };
-
-        expect(() => markdownService.renderKatex('$example$')).toThrowError(errorKatexNotLoaded);
-      });
-
-      it('should call katex with math expressions', () => {
-
-        global['katex'] = { renderToString: (tex: string, options?: KatexOptions) => '' };
-
-        spyOn(katex, 'renderToString');
-
-        const useCases = [
-          { tex: '$E=mc^2$' },
-          { tex: '$x^2 + y^2 = z^2$', options: { displayMode: true } },
-        ];
-
-        useCases.forEach(useCase => {
-          markdownService.renderKatex(useCase.tex, useCase.options);
-          expect(katex.renderToString).toHaveBeenCalledWith(useCase.tex.replace(/\$/gm, ''), useCase.options);
-          katex.renderToString.calls.reset();
         });
       });
     });

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -108,18 +108,24 @@ describe('MarkdowService', () => {
 
     describe('parse', () => {
 
-      it('should return parsed markdown correctly', () => {
+      it('should extend marked renderer when mermaid is true', () => {
 
-        const mockRaw = '### Markdown-x';
+        const mermaid = 'graph TD; A-->B;';
+        const mockRaw = `\`\`\`mermaid\n${mermaid}\n\`\`\``;
 
-        expect(markdownService.parse(mockRaw)).toBe(marked(mockRaw));
+        const parsed = markdownService.parse(mockRaw, { mermaid: true });
+
+        expect(parsed).toBe(`<div class="mermaid">${mermaid}</div>`);
       });
 
-      it('should return empty string when raw is null/undefined/empty', () => {
+      it('should not extend marked renderer when mermaid is false', () => {
 
-        expect(markdownService.parse(null!)).toBe('');
-        expect(markdownService.parse(undefined!)).toBe('');
-        expect(markdownService.parse('')).toBe('');
+        const mermaid = 'graph TD; A-->B;';
+        const mockRaw = `\`\`\`mermaid\n${mermaid}\n\`\`\``;
+
+        const parsed = markdownService.parse(mockRaw, { mermaid: false });
+
+        expect(parsed).toBe(marked(mockRaw));
       });
 
       it('should remove leading whitespaces offset while keeping indent', () => {
@@ -338,6 +344,20 @@ describe('MarkdowService', () => {
 
         expect(() => markdownService.parse(mockRaw)).not.toThrowError();
         expect(markdownService.parse(mockRaw)).toBe(expected);
+      });
+
+      it('should return parsed markdown correctly', () => {
+
+        const mockRaw = '### Markdown-x';
+
+        expect(markdownService.parse(mockRaw)).toBe(marked(mockRaw));
+      });
+
+      it('should return empty string when raw is null/undefined/empty', () => {
+
+        expect(markdownService.parse(null!)).toBe('');
+        expect(markdownService.parse(undefined!)).toBe('');
+        expect(markdownService.parse('')).toBe('');
       });
 
       it('should not sanitize parsed markdown', () => {

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -74,7 +74,7 @@ export class MarkdownService {
   };
 
   private readonly DEFAULT_MARKED_OPTIONS: MarkedOptions = {
-    renderer: this.extendRenderer(new MarkedRenderer()),
+    renderer: new MarkedRenderer(),
   };
 
   private readonly DEFAULT_MERMAID_OPTIONS: MermaidAPI.Config = {
@@ -181,19 +181,9 @@ export class MarkdownService {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const defaultCode = renderer.code;
     renderer.code = function (code: string, language: string | undefined, isEscaped: boolean) {
-      const mermaidSearchResult = /^sequenceDiagram/.exec(code)
-      || /^graph/.exec(code)
-      || /^flowchart/.exec(code)
-      || /^erDiagram/.exec(code)
-      || /^journey/.exec(code)
-      || /^gantt/.exec(code)
-      || /^pie/.exec(code)
-      || /^requirementDiagram/.exec(code)
-      || /^gitGraph/.exec(code);
-      const rendererCode = mermaidSearchResult !== null && mermaidSearchResult.length > 0
+      return language === 'mermaid'
         ? `<div class="mermaid">${code}</div>`
         : defaultCode.call(this, code, language, isEscaped);
-      return rendererCode;
     };
 
     extendedRenderer.ɵNgxMarkdownRendererExtended = true;

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -2,13 +2,14 @@ import { isPlatformBrowser } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional, PLATFORM_ID, SecurityContext } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { marked } from 'marked';
+import { marked, Renderer } from 'marked';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { KatexOptions } from './katex-options';
 import { MarkedOptions } from './marked-options';
 import { MarkedRenderer } from './marked-renderer';
+import { MermaidAPI } from './mermaid-options';
 
 declare let joypixels: {
   shortnameToUnicode(input: string): string;
@@ -18,6 +19,12 @@ declare let katex: {
   renderToString(tex: string, options?: KatexOptions): string;
 };
 
+declare let mermaid: {
+  initialize: (options: MermaidAPI.Config) => void;
+  init: (nodes: string | Node | NodeList) => void;
+  parse: (text: string) => string;
+};
+
 declare let Prism: {
   highlightAllUnder: (element: Element | Document) => void;
 };
@@ -25,23 +32,60 @@ declare let Prism: {
 /* eslint-disable max-len */
 export const errorJoyPixelsNotLoaded = '[ngx-markdown] When using the `emoji` attribute you *have to* include Emoji-Toolkit files to `angular.json` or use imports. See README for more information';
 export const errorKatexNotLoaded = '[ngx-markdown] When using the `katex` attribute you *have to* include KaTeX files to `angular.json` or use imports. See README for more information';
+export const errorMermaidNotLoaded = '[ngx-markdown] When using the `mermaid` attribute you *have to* include Mermaid files to `angular.json` or use imports. See README for more information';
 export const errorSrcWithoutHttpClient = '[ngx-markdown] When using the `src` attribute you *have to* pass the `HttpClient` as a parameter of the `forRoot` method. See README for more information';
 /* eslint-enable max-len */
 
 export const SECURITY_CONTEXT = new InjectionToken<SecurityContext>('SECURITY_CONTEXT');
 
+export interface ParseOptions {
+  decodeHtml?: boolean;
+  emoji?: boolean;
+  katex?: boolean;
+  katexOptions?: KatexOptions;
+  mermaid?: boolean;
+  markedOptions?: MarkedOptions;
+}
+
+export interface RenderOptions {
+  mermaid?: boolean;
+  mermaidOptions?: MermaidAPI.Config;
+}
+
+export class ExtendedRenderer extends Renderer {
+  ɵNgxMarkdownRendererExtended = false;
+}
+
 @Injectable()
 export class MarkdownService {
 
-  private readonly initialMarkedOptions: MarkedOptions = {
-    renderer: new MarkedRenderer(),
+  private readonly DEFAULT_COMPILE_OPTIONS: ParseOptions = {
+    decodeHtml: false,
+    emoji: false,
+    katex: false,
+    katexOptions: undefined,
+    mermaid: false,
+    markedOptions: undefined,
+  };
+
+  private readonly DEFAULT_RENDER_OPTIONS: RenderOptions = {
+    mermaid: false,
+    mermaidOptions: undefined,
+  };
+
+  private readonly DEFAULT_MARKED_OPTIONS: MarkedOptions = {
+    renderer: this.extendRenderer(new MarkedRenderer()),
+  };
+
+  private readonly DEFAULT_MERMAID_OPTIONS: MermaidAPI.Config = {
+    startOnLoad: false,
   };
 
   private _options: MarkedOptions | undefined;
 
   get options(): MarkedOptions { return this._options!; }
   set options(value: MarkedOptions) {
-    this._options = { ...this.initialMarkedOptions, ...value };
+    this._options = { ...this.DEFAULT_MARKED_OPTIONS, ...value };
   }
 
   get renderer(): MarkedRenderer { return this.options.renderer!; }
@@ -59,12 +103,40 @@ export class MarkdownService {
     this.options = options;
   }
 
-  compile(markdown: string, decodeHtml = false, emojify = false,  markedOptions = this.options): string {
+  parse(markdown: string, options: ParseOptions = this.DEFAULT_COMPILE_OPTIONS): string {
+    const {
+      decodeHtml,
+      emoji,
+      katex,
+      katexOptions,
+      mermaid,
+      markedOptions = this.DEFAULT_MARKED_OPTIONS,
+    } = options;
+
+    if (mermaid) {
+      this.renderer = this.extendRenderer(markedOptions.renderer || new Renderer());
+    }
+
     const trimmed = this.trimIndentation(markdown);
     const decoded = decodeHtml ? this.decodeHtml(trimmed) : trimmed;
-    const emojified = emojify ? this.renderEmoji(decoded) : decoded;
-    const compiled = marked(emojified, markedOptions);
-    return this.sanitizer.sanitize(this.securityContext, compiled) || '';
+    const emojified = emoji ? this.renderEmoji(decoded) : decoded;
+    const katexed = katex ? this.renderKatex(emojified, katexOptions) : emojified;
+    const marked = this.renderMarked(katexed, markedOptions);
+
+    return this.sanitizer.sanitize(this.securityContext, marked) || '';
+  }
+
+  render(element: HTMLElement, options: RenderOptions = this.DEFAULT_RENDER_OPTIONS): void {
+    const {
+      mermaid,
+      mermaidOptions,
+    } = options;
+
+    if (mermaid) {
+      this.renderMermaid(element, mermaidOptions);
+    }
+
+    this.highlight(element);
   }
 
   getSource(src: string): Observable<string> {
@@ -80,24 +152,15 @@ export class MarkdownService {
     if (!isPlatformBrowser(this.platform)) {
       return;
     }
-    if (typeof Prism !== 'undefined') {
-      if (!element) {
-        element = document;
-      }
-      const noLanguageElements = element.querySelectorAll('pre code:not([class*="language-"])');
-      Array.prototype.forEach.call(noLanguageElements, (x: Element) => x.classList.add('language-none'));
-      Prism.highlightAllUnder(element);
+    if (typeof Prism === 'undefined' || typeof Prism.highlightAllUnder === 'undefined') {
+      return;
     }
-  }
-
-  renderKatex(html: string, options?: KatexOptions): string {
-    if (!isPlatformBrowser(this.platform)) {
-      return html;
+    if (!element) {
+      element = document;
     }
-    if (typeof katex === 'undefined' || typeof katex.renderToString === 'undefined') {
-      throw new Error(errorKatexNotLoaded);
-    }
-    return html.replace(/\$([^\s][^$]*?[^\s])\$/gm, (_, tex) => katex.renderToString(tex, options));
+    const noLanguageElements = element.querySelectorAll('pre code:not([class*="language-"])');
+    Array.prototype.forEach.call(noLanguageElements, (x: Element) => x.classList.add('language-none'));
+    Prism.highlightAllUnder(element);
   }
 
   private decodeHtml(html: string): string {
@@ -109,6 +172,35 @@ export class MarkdownService {
     return textarea.value;
   }
 
+  private extendRenderer(renderer: Renderer): Renderer {
+    const extendedRenderer = renderer as ExtendedRenderer;
+    if (extendedRenderer.ɵNgxMarkdownRendererExtended === true) {
+      return renderer;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const defaultCode = renderer.code;
+    renderer.code = function (code: string, language: string | undefined, isEscaped: boolean) {
+      const mermaidSearchResult = /^sequenceDiagram/.exec(code)
+      || /^graph/.exec(code)
+      || /^flowchart/.exec(code)
+      || /^erDiagram/.exec(code)
+      || /^journey/.exec(code)
+      || /^gantt/.exec(code)
+      || /^pie/.exec(code)
+      || /^requirementDiagram/.exec(code)
+      || /^gitGraph/.exec(code);
+      const rendererCode = mermaidSearchResult !== null && mermaidSearchResult.length > 0
+        ? `<div class="mermaid">${code}</div>`
+        : defaultCode.call(this, code, language, isEscaped);
+      return rendererCode;
+    };
+
+    extendedRenderer.ɵNgxMarkdownRendererExtended = true;
+
+    return renderer;
+  }
+
   private handleExtension(src: string, markdown: string): string {
     const extension = src
       ? src.split('?')[0].split('.').splice(-1).join()
@@ -116,6 +208,13 @@ export class MarkdownService {
     return extension !== 'md'
       ? '```' + extension + '\n' + markdown + '\n```'
       : markdown;
+  }
+
+  private renderMarked(html: string, markedOptions: MarkedOptions): string {
+    if (!isPlatformBrowser(this.platform)) {
+      return html;
+    }
+    return marked(html, markedOptions);
   }
 
   private renderEmoji(html: string): string {
@@ -126,6 +225,31 @@ export class MarkdownService {
       throw new Error(errorJoyPixelsNotLoaded);
     }
     return joypixels.shortnameToUnicode(html);
+  }
+
+  private renderKatex(html: string, options?: KatexOptions): string {
+    if (!isPlatformBrowser(this.platform)) {
+      return html;
+    }
+    if (typeof katex === 'undefined' || typeof katex.renderToString === 'undefined') {
+      throw new Error(errorKatexNotLoaded);
+    }
+    return html.replace(/\$([^\s][^$]*?[^\s])\$/gm, (_, tex) => katex.renderToString(tex, options));
+  }
+
+  private renderMermaid(element: HTMLElement, options: MermaidAPI.Config = this.DEFAULT_MERMAID_OPTIONS): void {
+    if (!isPlatformBrowser(this.platform)) {
+      return;
+    }
+    if (typeof mermaid === 'undefined' || typeof mermaid.init === 'undefined') {
+      throw new Error(errorMermaidNotLoaded);
+    }
+    const mermaidElements = element.querySelectorAll('.mermaid');
+    if (mermaidElements.length === 0) {
+      return;
+    }
+    mermaid.initialize(options);
+    mermaid.init(mermaidElements);
   }
 
   private trimIndentation(markdown: string): string {

--- a/lib/src/mermaid-options.ts
+++ b/lib/src/mermaid-options.ts
@@ -1,0 +1,327 @@
+/* eslint-disable */
+export namespace MermaidAPI {
+  export enum SecurityLevel {
+    /**
+     * (default) tags in text are encoded, click functionality is disabled
+     */
+    Strict = 'strict',
+
+    /**
+     * tags in text are allowed, click functionality is enabled
+     */
+    Loose = 'loose',
+
+    /**
+     * html tags in text are allowed, (only script element is removed), click functionality is enabled
+     */
+    Antiscript = 'antiscript',
+
+    /**
+     * with this security level all rendering takes place in a sandboxed iframe.
+     * This prevent any javascript running in the context.
+     * This may hinder interactive functionality of the diagram like scripts,
+     * popups in sequence diagram or links to other tabs/targets etc.
+     */
+    Sandbox = 'sandbox'
+  }
+
+  export enum Theme {
+    /**
+     * Designed to modified, as the name implies it is supposed to be used as the base for making custom themes.
+     */
+    Base = 'base',
+
+    /**
+     * A theme full of light greens that is easy on the eyes.
+     */
+    Forest = 'forest',
+
+    /**
+     * A theme that would go well with other dark colored elements.
+     */
+    Dark = 'dark',
+
+    /**
+     *  The default theme for all diagrams.
+     */
+    Default = 'default',
+
+    /**
+     * The theme to be used for black and white printing
+     */
+    Neutral = 'neutral'
+  }
+
+  export enum LogLevel {
+    Debug = 1,
+    Info,
+    Warn,
+    Error,
+    Fatal
+  }
+
+  export interface FlowChartConfig {
+    /**
+     * **diagramPadding** - amount of padding around the diagram as a whole
+     * default: 8
+     */
+    diagramPadding?: number | undefined;
+
+    /**
+     * **htmlLabels** - Flag for setting whether or not a html tag should be used for rendering labels
+     * on the edges
+     * default: true
+     */
+    htmlLabels?: boolean | undefined;
+
+    /**
+     * **nodeSpacing** - Defines the spacing between nodes on the same level
+     * default: 50
+     */
+    nodeSpacing?: number | undefined;
+
+    /**
+     * **rankSpacing** - Defines the spacing between nodes on different levels
+     * default: 50
+     */
+    rankSpacing?: number | undefined;
+
+    /**
+     * default: 'monotoneX'
+     */
+    curve?: string | undefined;
+
+    /**
+     * **rankSpacing** - Only used in new experimental rendering, represents the padding between the labels and the shape
+     * default: 15
+     */
+    padding?: number | undefined;
+
+    /**
+     * default: true
+     */
+    useMaxWidth?: boolean | undefined;
+  }
+
+  export interface SequenceDiagramConfig {
+    /**
+     * **diagramMarginX** - margin to the right and left of the sequence diagram
+     * default: 50
+     */
+    diagramMarginX?: number | undefined;
+
+    /**
+     * **diagramMarginY** - margin to the over and under the sequence diagram
+     * default: 10
+     */
+    diagramMarginY?: number | undefined;
+
+    /**
+     * **actorMargin** - Margin between actors
+     * default: 10
+     */
+    actorMargin?: number | undefined;
+
+    /**
+     * **width** - Width of actor boxes
+     * default: 150
+     */
+    width?: number | undefined;
+
+    /**
+     * **height** - Height of actor boxes
+     * default: 65
+     */
+    height?: number | undefined;
+
+    /**
+     * **boxMargin** - Margin around loop boxes
+     * default: 10
+     */
+    boxMargin?: number | undefined;
+
+    /**
+     * **boxTextMargin** - margin around the text in loop/alt/opt boxes
+     * default: 5
+     */
+    boxTextMargin?: number | undefined;
+
+    /**
+     * **noteMargin** - margin around notes
+     * default: 10
+     */
+    noteMargin?: number | undefined;
+
+    /**
+     * **messageMargin** - Space between messages
+     * default: 35
+     */
+    messageMargin?: number | undefined;
+
+    /**
+     * **mirrorActors** - mirror actors under diagram
+     * default: true
+     */
+    mirrorActors?: boolean | undefined;
+
+    /**
+     * **bottomMarginAdj** - Depending on css styling this might need adjustment.
+     * Prolongs the edge of the diagram downwards
+     * default: 1
+     */
+    bottomMarginAdj?: number | undefined;
+
+    /**
+     * **useMaxWidth** - when this flag is set the height and width is set to 100% and is then scaling with the
+     * available space if not the absolute space required is used
+     * default: true
+     */
+    useMaxWidth?: boolean | undefined;
+
+    /**
+     * This will display arrows that start and begin at the same node as right angles, rather than a curve
+     * Default value: false
+     */
+    rightAngles?: boolean | undefined;
+  }
+
+  export interface GanttConfig {
+    /**
+     * **titleTopMargin** - margin top for the text over the gantt diagram
+     * default: 25
+     */
+    titleTopMargin?: number | undefined;
+
+    /**
+     * **barHeight** - the height of the bars in the graph
+     * default: 20
+     */
+    barHeight?: number | undefined;
+
+    /**
+     * **barGap** - the margin between the different activities in the gantt diagram
+     * default: 4
+     */
+    barGap?: number | undefined;
+
+    /**
+     *  **topPadding** - margin between title and gantt diagram and between axis and gantt diagram.
+     * default: 50
+     */
+    topPadding?: number | undefined;
+
+    /**
+     *  **leftPadding** - the space allocated for the section name to the left of the activities.
+     * default: 75
+     */
+    leftPadding?: number | undefined;
+
+    /**
+     *  **gridLineStartPadding** - Vertical starting position of the grid lines
+     * default: 35
+     */
+    gridLineStartPadding?: number | undefined;
+
+    /**
+     *  **fontSize** - font size ...
+     * default: 11
+     */
+    fontSize?: number | undefined;
+
+    /**
+     * **fontFamily** - font family ...
+     * default:  '"Open-Sans", "sans-serif"'
+     */
+    fontFamily?: string | undefined;
+
+    /**
+     * **numberSectionStyles** - the number of alternating section styles
+     * default: 4
+     */
+    numberSectionStyles?: number | undefined;
+
+    /**
+     * **axisFormat** - datetime format of the axis, this might need adjustment to match your locale and preferences
+     * default: '%Y-%m-%d'
+     */
+    axisFormat?: string | undefined;
+  }
+
+  export interface Config {
+    /**
+     * ### securityLevel
+     * This changes the default behaviour of mermaid so that after upgrade to 8.2,
+     * unless the `securityLevel` is not changed, tags in flowcharts are encoded as tags and clicking is disabled.
+     * **sandbox** security level is still in the beta version.
+     * default: SecurityLevel.Strict
+     */
+    securityLevel?: SecurityLevel | undefined;
+
+    theme?: Theme | undefined;
+
+    themeVariables?: any; // [todo]
+
+    themeCSS?: string | undefined;
+
+    maxTextSize?: number | undefined;
+
+    darkMode?: boolean | undefined;
+
+    fontFamily?: string | undefined;
+
+    /**
+     * logLevel , decides the amount of logging to be used.
+     * default: LogLevel.Fatal
+     */
+    logLevel?: LogLevel | undefined;
+
+    /**
+     * **startOnLoad** - This options controls whether or mermaid starts when the page loads
+     * default: true
+     */
+    startOnLoad?: boolean | undefined;
+
+    /**
+     * **arrowMarkerAbsolute** - This options controls whether or arrow markers in html code will be absolute paths or
+     * an anchor, #. This matters if you are using base tag settings.
+     * default: false
+     */
+    arrowMarkerAbsolute?: boolean | undefined;
+
+    secure?: Array<keyof Config> | undefined;
+
+    deterministicIds?: boolean | undefined;
+
+    deterministicIDSeed?: string | undefined;
+
+    /**
+     * ### flowchart
+     * *The object containing configurations specific for flowcharts*
+     */
+    flowchart?: FlowChartConfig | undefined;
+
+    /**
+     * ###  sequenceDiagram
+     * The object containing configurations specific for sequence diagrams
+     */
+    sequence?: SequenceDiagramConfig | undefined;
+
+    /**
+     * ### gantt
+     * The object containing configurations specific for gantt diagrams*
+     */
+    gantt?: GanttConfig | undefined;
+
+    journey?: any; // [todo]
+
+    class?: any; // [todo]
+
+    git?: any; // [todo]
+
+    state?: any; // [todo]
+
+    pie?: any; // [todo]
+
+    requirement?: any; // [todo]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@angular/common": "~13.0.0",
     "@angular/compiler": "~13.0.0",
     "@angular/core": "~13.0.0",
-    "@angular/flex-layout": "12.0.0-beta.35",
+    "@angular/flex-layout": "13.0.0-beta.38",
     "@angular/forms": "~13.0.0",
     "@angular/material": "~13.0.0",
     "@angular/platform-browser": "~13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,12 +246,12 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/flex-layout@12.0.0-beta.35":
-  version "12.0.0-beta.35"
-  resolved "https://registry.yarnpkg.com/@angular/flex-layout/-/flex-layout-12.0.0-beta.35.tgz#b52c3c82608cbb92a119f8dcde2a5b98186fe558"
-  integrity sha512-nPi2MGDFuCacwWHqxF/G7lUJd2X99HbLjjUvKXnyLwyCIVgH1sfS52su2wYbVYWJRqAVAB2/VMlrtW8Khr8hDA==
+"@angular/flex-layout@13.0.0-beta.38":
+  version "13.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@angular/flex-layout/-/flex-layout-13.0.0-beta.38.tgz#b0993a255ba51d2cfd16537ba8a8d88c3adf6587"
+  integrity sha512-kcWb7CcoHbvw7fjo/knizWVmSSmvaTnr8v1ML6zOdxu1PK9UPPOcOS8RTm6fy61zoC2LABivP1/6Z2jF5XfpdQ==
   dependencies:
-    tslib "^2.1.0"
+    tslib "^2.3.0"
 
 "@angular/forms@~13.0.0":
   version "13.0.0"
@@ -1262,6 +1262,11 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
+"@braintree/sanitize-url@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz#fe364f025ba74f6de6c837a84ef44bdb1d61e68f"
+  integrity sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w==
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -1992,7 +1997,7 @@ ansi-colors@4.1.1, ansi-colors@^4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.1.0, ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -2019,6 +2024,11 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -2040,6 +2050,13 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+app-path@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/app-path/-/app-path-3.3.0.tgz#0342a909db37079c593979c720f99e872475eba3"
+  integrity sha512-EAgEXkdcxH1cgEePOSsmUtw9ItPl0KTxnh/pj9ZbhvbKbij9x0oX6PWpGnorDr0DS5AosLgoa5n3T/hZmKQpYA==
+  dependencies:
+    execa "^1.0.0"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -2292,7 +2309,7 @@ base64-arraybuffer@~1.0.1:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz#87bd13525626db4a9838e00a508c2b73efcf348c"
   integrity sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==
 
-base64-js@^1.2.0, base64-js@^1.3.1:
+base64-js@^1.2.0, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2565,7 +2582,18 @@ chalk@4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^2.0.0:
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
+chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2733,6 +2761,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2, commander@^2.15.0, commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
@@ -2740,10 +2773,10 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.15.0, commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^8.0.0:
   version "8.3.0"
@@ -2972,6 +3005,17 @@ critters@0.0.14:
     postcss "^8.3.7"
     pretty-bytes "^5.3.0"
 
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -3066,6 +3110,528 @@ custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
   integrity sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
+
+cypress-image-snapshot@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/cypress-image-snapshot/-/cypress-image-snapshot-4.0.1.tgz#59084e713a8d03500c8e053ad7a76f3f18609648"
+  integrity sha512-PBpnhX/XItlx3/DAk5ozsXQHUi72exybBNH5Mpqj1DVmjq+S5Jd9WE5CRa4q5q0zuMZb2V2VpXHth6MjFpgj9Q==
+  dependencies:
+    chalk "^2.4.1"
+    fs-extra "^7.0.1"
+    glob "^7.1.3"
+    jest-image-snapshot "4.2.0"
+    pkg-dir "^3.0.0"
+    term-img "^4.0.0"
+
+d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.1.6.tgz#0342c835925826f49b4d16eb7027aec334ffc97d"
+  integrity sha512-DCbBBNuKOeiR9h04ySRBMW52TFVc91O9wJziuyXw6Ztmy8D3oZbmCkOO3UHKC7ceNJsN2Mavo9+vwV8EAEUXzA==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@1:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
+  integrity sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.1.6.tgz#b0a22c7372cabec128bdddf9bddc058592f89e9b"
+  integrity sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
+  integrity sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==
+  dependencies:
+    d3-array "1"
+    d3-path "1"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
+  integrity sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==
+  dependencies:
+    d3-array "^1.1.1"
+
+d3-contour@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-3.0.1.tgz#2c64255d43059599cd0dba8fe4cc3d51ccdd9bbd"
+  integrity sha512-0Oc4D0KyhwhM7ZL0RMnfGycLN7hxHB8CMmwZ3+H26PWAG0ozNuYG5hXSDNgmP1SgJkQMrlG6cP20HoaSbvcJTQ==
+  dependencies:
+    d3-array "2 - 3"
+
+d3-delaunay@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.2.tgz#7fd3717ad0eade2fc9939f4260acfb503f984e92"
+  integrity sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==
+  dependencies:
+    delaunator "5"
+
+d3-dispatch@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+d3-drag@1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
+  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+d3-dsv@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+d3-ease@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
+  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.2.0.tgz#15ce2ecfc41b092b1db50abd2c552c2316cf7fc7"
+  integrity sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==
+  dependencies:
+    d3-dsv "1"
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.2.1.tgz#fd29a5d1ff181c9e7f0669e4bd72bdb0e914ec0b"
+  integrity sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-quadtree "1"
+    d3-timer "1"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+d3-format@1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
+  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+d3-geo@1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.12.1.tgz#7fc2ab7414b72e59fbcbd603e80d9adc029b035f"
+  integrity sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==
+  dependencies:
+    d3-array "1"
+
+d3-geo@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.0.1.tgz#4f92362fd8685d93e3b1fae0fd97dc8980b1ed7e"
+  integrity sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@1:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
+  integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+d3-interpolate@1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 3", d3-path@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.0.1.tgz#f09dec0aaffd770b7995f1a399152bf93052321e"
+  integrity sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==
+
+d3-polygon@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.6.tgz#0bf8cb8180a6dc107f518ddf7975e12abbfbd38e"
+  integrity sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+d3-quadtree@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.7.tgz#ca8b84df7bb53763fe3c2f24bd435137f4e53135"
+  integrity sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.2.tgz#2833be7c124360bf9e2d3fd4f33847cfe6cab291"
+  integrity sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-scale-chromatic@1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#54e333fc78212f439b14641fb55801dd81135a98"
+  integrity sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
+
+d3-scale-chromatic@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
+  integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+d3-selection@1, d3-selection@^1.1.0:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
+  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
+
+"d3-selection@2 - 3", d3-selection@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@1:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+d3-shape@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.1.0.tgz#c8a495652d83ea6f524e482fca57aa3f8bc32556"
+  integrity sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==
+  dependencies:
+    d3-path "1 - 3"
+
+d3-time-format@2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
+  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
+  dependencies:
+    d3-time "1"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.0.0.tgz#65972cb98ae2d4954ef5c932e8704061335d4975"
+  integrity sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==
+  dependencies:
+    d3-array "2 - 3"
+
+d3-timer@1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+d3-transition@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
+  integrity sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+"d3-transition@2 - 3", d3-transition@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-voronoi@1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+  integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
+
+d3-zoom@1:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.8.3.tgz#b6a3dbe738c7763121cd05b8a7795ffe17f4fc0a"
+  integrity sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^5.14:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-5.16.0.tgz#9c5e8d3b56403c79d4ed42fbd62f6113f199c877"
+  integrity sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==
+  dependencies:
+    d3-array "1"
+    d3-axis "1"
+    d3-brush "1"
+    d3-chord "1"
+    d3-collection "1"
+    d3-color "1"
+    d3-contour "1"
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-dsv "1"
+    d3-ease "1"
+    d3-fetch "1"
+    d3-force "1"
+    d3-format "1"
+    d3-geo "1"
+    d3-hierarchy "1"
+    d3-interpolate "1"
+    d3-path "1"
+    d3-polygon "1"
+    d3-quadtree "1"
+    d3-random "1"
+    d3-scale "2"
+    d3-scale-chromatic "1"
+    d3-selection "1"
+    d3-shape "1"
+    d3-time "1"
+    d3-time-format "2"
+    d3-timer "1"
+    d3-transition "1"
+    d3-voronoi "1"
+    d3-zoom "1"
+
+d3@^7.0.0:
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.4.4.tgz#bfbf87487c37d3196efebd5a63e3a0ed8299d8ff"
+  integrity sha512-97FE+MYdAlV3R9P74+R3Uar7wUKkIFu89UWMjEaDhiJ9VxKvqaMxauImy8PC2DdBkdM2BxJOIoLxPrcZUyrKoQ==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "3"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
+dagre-d3@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/dagre-d3/-/dagre-d3-0.6.4.tgz#0728d5ce7f177ca2337df141ceb60fbe6eeb7b29"
+  integrity sha512-e/6jXeCP7/ptlAM48clmX4xTZc5Ek6T6kagS7Oz2HrYSdqcLZFLqpAfh7ldbZRFfxCZVyh61NEPR08UQRVxJzQ==
+  dependencies:
+    d3 "^5.14"
+    dagre "^0.8.5"
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
+
+dagre@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
+  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
+  dependencies:
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -3216,6 +3782,13 @@ del@^6.0.0:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+delaunator@5:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.0.tgz#60f052b28bd91c9b4566850ebf7756efe821d81b"
+  integrity sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==
+  dependencies:
+    robust-predicates "^3.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -3335,6 +3908,11 @@ domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.6.tgz#2e019d7d7617aacac07cbbe3d88ae3ad354cf875"
+  integrity sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==
+
 domutils@^2.6.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
@@ -3395,6 +3973,13 @@ encoding@^0.1.12:
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
   dependencies:
     iconv-lite "^0.6.2"
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 engine.io-parser@~5.0.0:
   version "5.0.1"
@@ -3631,7 +4216,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -3853,6 +4438,19 @@ events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^5.0.0:
   version "5.1.1"
@@ -4090,6 +4688,13 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -4175,6 +4780,15 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
@@ -4254,6 +4868,18 @@ get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-stream@^6.0.0:
   version "6.0.1"
@@ -4386,6 +5012,11 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+glur@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/glur/-/glur-1.1.2.tgz#f20ea36db103bfc292343921f1f91e83c3467689"
+  integrity sha1-8g6jbbEDv8KSNDkh8fkeg8NGdok=
+
 graceful-fs@4.1.10:
   version "4.1.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.10.tgz#f2d720c22092f743228775c75e3612632501f131"
@@ -4400,6 +5031,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
+
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
 
 gumshoejs@^5.1.2:
   version "5.1.2"
@@ -4433,6 +5071,13 @@ hard-rejection@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+  dependencies:
+    ansi-regex "^2.0.0"
 
 has-bigints@^1.0.1:
   version "1.0.1"
@@ -4662,14 +5307,14 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
+iconv-lite@0.6, iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -4804,6 +5449,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 ip-regex@^4.0.0:
   version "4.3.0"
@@ -5064,6 +5714,11 @@ is-shared-array-buffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
   integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
 is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
@@ -5201,6 +5856,14 @@ istanbul-reports@^3.0.0:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+iterm2-version@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/iterm2-version/-/iterm2-version-4.2.0.tgz#b78069f747f34a772bc7dc17bda5bd9ed5e09633"
+  integrity sha512-IoiNVk4SMPu6uTcK+1nA5QaHNok2BMDLjSl5UomrOixe5g4GkylhPwuiGdw00ysSCrXAKNMfFTu+u/Lk5f6OLQ==
+  dependencies:
+    app-path "^3.2.0"
+    plist "^3.0.1"
+
 jake@^10.8.5:
   version "10.8.5"
   resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
@@ -5215,6 +5878,21 @@ jasmine-core@^3.6.0, jasmine-core@~3.10.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.10.1.tgz#7aa6fa2b834a522315c651a128d940eca553989a"
   integrity sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==
+
+jest-image-snapshot@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-4.2.0.tgz#559d7ade69e9918517269cef184261c80029a69e"
+  integrity sha512-6aAqv2wtfOgxiJeBayBCqHo1zX+A12SUNNzo7rIxiXh6W6xYVu8QyHWkada8HeRi+QUTHddp0O0Xa6kmQr+xbQ==
+  dependencies:
+    chalk "^1.1.3"
+    get-stdin "^5.0.1"
+    glur "^1.1.2"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    pixelmatch "^5.1.0"
+    pngjs "^3.4.0"
+    rimraf "^2.6.2"
+    ssim.js "^3.1.1"
 
 jest-worker@^27.0.6:
   version "27.3.1"
@@ -5316,6 +5994,13 @@ jsonfile@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
   integrity sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -5430,6 +6115,11 @@ katex@^0.15.1:
   integrity sha512-KIk+gizli0gl1XaJlCYS8/donGMbzXYTka6BbH3AgvDJTOwyDY4hJ+YmzJ1F0y/3XzX5B9ED8AqB2Hmn2AZ0uA==
   dependencies:
     commander "^8.0.0"
+
+khroma@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-1.4.1.tgz#ad6a5b6a972befc5112ce5129887a1a83af2c003"
+  integrity sha512-+GmxKvmiRuCcUYDgR7g5Ngo0JEDeOsGdNONdU2zsiBQaK4z19Y2NvXqfEDE0ZiIrg45GTZyAnPLVsLZZACYm3Q==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5556,6 +6246,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -5578,7 +6276,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.14.0, lodash@^4.17.14, lodash@^4.17.21:
+lodash@^4.14.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5735,6 +6433,22 @@ merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+mermaid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-9.0.1.tgz#b804f372d827936ab8a8cbde72a5b79fb2629680"
+  integrity sha512-TXXffALLhCACez+MUky4cOOcGXEXiJhHwN8eRV7bBqD8F6KdcjssyPZClVgzrC2KQzSGLqQkj7ce8ea7MhWz+Q==
+  dependencies:
+    "@braintree/sanitize-url" "^6.0.0"
+    cypress-image-snapshot "^4.0.1"
+    d3 "^7.0.0"
+    dagre "^0.8.5"
+    dagre-d3 "^0.6.4"
+    dompurify "2.3.6"
+    graphlib "^2.1.8"
+    khroma "^1.4.1"
+    moment-mini "^2.24.0"
+    stylis "^4.0.10"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -5951,6 +6665,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment-mini@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment-mini/-/moment-mini-2.24.0.tgz#fa68d98f7fe93ae65bf1262f6abb5fb6983d8d18"
+  integrity sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -6079,6 +6798,7 @@ ng-packagr@^13.0.3:
     emoji-toolkit "^6.6.0"
     katex "^0.15.1"
     marked "^4.0.10"
+    mermaid "^9.0.1"
     prismjs "^1.25.0"
     tslib "^2.3.0"
 
@@ -6089,6 +6809,11 @@ nice-napi@^1.0.2:
   dependencies:
     node-addon-api "^3.0.0"
     node-gyp-build "^4.2.2"
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-addon-api@^3.0.0:
   version "3.2.1"
@@ -6213,6 +6938,13 @@ npm-registry-fetch@^11.0.0:
     minizlib "^2.0.0"
     npm-package-arg "^8.0.0"
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
+  dependencies:
+    path-key "^2.0.0"
+
 npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
@@ -6334,7 +7066,7 @@ on-headers@~1.0.2:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -6429,7 +7161,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -6449,6 +7181,13 @@ p-locate@^2.0.0:
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -6615,6 +7354,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-key@^2.0.0, path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -6700,6 +7444,13 @@ piscina@3.1.0:
   optionalDependencies:
     nice-napi "^1.0.2"
 
+pixelmatch@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-5.3.0.tgz#5e5321a7abedfb7962d60dbf345deda87cb9560a"
+  integrity sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==
+  dependencies:
+    pngjs "^6.0.0"
+
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
@@ -6707,12 +7458,37 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
+
 pkg-dir@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+plist@^3.0.1:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.5.tgz#2cbeb52d10e3cdccccf0c11a63a85d830970a987"
+  integrity sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==
+  dependencies:
+    base64-js "^1.5.1"
+    xmlbuilder "^9.0.7"
+
+pngjs@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
+  integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+
+pngjs@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821"
+  integrity sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==
 
 portfinder@^1.0.28:
   version "1.0.28"
@@ -7154,6 +7930,14 @@ psl@^1.1.28:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -7538,6 +8322,11 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+robust-predicates@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.1.tgz#ecde075044f7f30118682bd9fb3f123109577f9a"
+  integrity sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==
+
 rollup-plugin-sourcemaps@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz#bf93913ffe056e414419607f1d02780d7ece84ed"
@@ -7564,6 +8353,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs-for-await@0.0.2:
   version "0.0.2"
@@ -7656,7 +8450,7 @@ selfsigned@^1.10.11:
   dependencies:
     node-forge "^0.10.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -7766,12 +8560,24 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  dependencies:
+    shebang-regex "^1.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -8040,6 +8846,11 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+ssim.js@^3.1.1:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/ssim.js/-/ssim.js-3.5.0.tgz#d7276b9ee99b57a5ff0db34035f02f35197e62df"
+  integrity sha512-Aj6Jl2z6oDmgYFFbQqK7fght19bXdOxY7Tj03nF+03M9gCBAjeIiO8/PlEGMfKDwYpw4q6iBqVq2YuREorGg/g==
+
 ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
@@ -8143,6 +8954,11 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
@@ -8159,6 +8975,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+stylis@^4.0.10:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.1.tgz#e46c6a9bbf7c58db1e65bb730be157311ae1fe12"
+  integrity sha512-lVrM/bNdhVX2OgBFNa2YJ9Lxj7kPzylieHd3TNjuGE0Re9JB7joL5VUKOVH1kdNNJTgGPpT8hmwIAPLaSyEVFQ==
 
 stylus-loader@6.2.0:
   version "6.2.0"
@@ -8182,6 +9003,11 @@ stylus@0.55.0, stylus@^0.55.0:
     sax "~1.2.4"
     semver "^6.3.0"
     source-map "^0.7.3"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -8236,6 +9062,14 @@ tar@^6.0.2, tar@^6.1.0, tar@^6.1.2:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+term-img@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/term-img/-/term-img-4.1.0.tgz#5b170961f7aa20b2f3b22deb8ad504beb963a8a5"
+  integrity sha512-DFpBhaF5j+2f7kheKFc1ajsAUUDGOaNPpKPtiIMxlbfud6mvfFZuWGnTRpaujUa5J7yl6cIw/h6nyr4mSsENPg==
+  dependencies:
+    ansi-escapes "^4.1.0"
+    iterm2-version "^4.1.0"
 
 terser-webpack-plugin@^5.1.3:
   version "5.2.4"
@@ -8366,7 +9200,7 @@ tsconfig-paths@^3.11.0, tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.3.1, tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0:
+tslib@2.3.1, tslib@^2.0.0, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -8773,7 +9607,7 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
-which@^1.2.1:
+which@^1.2.1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -8827,6 +9661,11 @@ xmlbuilder@12.0.0:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-12.0.0.tgz#e2ed675e06834a089ddfb84db96e2c2b03f78c1a"
   integrity sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==
+
+xmlbuilder@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xxhashjs@~0.2.2:
   version "0.2.2"


### PR DESCRIPTION
### Refactoring and Mermaid integration

⚠ Breaking changes
- `MarkdownService.compile` function has been renamed to `parse` and its parameters combined into the `parseOptions` object;
- `MarkdownService.render` function has been added to render elements once markdown has been parsed into HTML;
- `MarkdownService.renderKatex` function is now private and called within the `MarkdownService.render` function;

Fixes #370 