### PR TITLE
Update PrismJS dependency to 1.28.0 version

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -29,7 +29,7 @@
     "emoji-toolkit": "^6.6.0",
     "katex": "^0.15.1",
     "marked": "^4.0.10",
-    "prismjs": "^1.25.0",
+    "prismjs": "^1.28.0",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Pull request for resolving [issue](https://github.com/jfcere/ngx-markdown/issues/389)