### PR TITLE
Fix backward compatibility for rxjs 6

### DIFF
--- a/lib/src/clipboard-button.component.ts
+++ b/lib/src/clipboard-button.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { distinctUntilChanged, map, mapTo, merge, of, shareReplay, startWith, Subject, switchMap, timer } from 'rxjs';
+import { merge, of, Subject, timer } from 'rxjs';
+import { distinctUntilChanged, map, mapTo, shareReplay, startWith, switchMap } from 'rxjs/operators';
 
 const BUTTON_TEXT_COPY = 'Copy';
 const BUTTON_TEXT_COPIED = 'Copied';

--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -12,7 +12,8 @@ import {
   Type,
   ViewContainerRef,
 } from '@angular/core';
-import { Subject, takeUntil } from 'rxjs';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { KatexOptions } from './katex-options';
 import { MarkdownService, ParseOptions, RenderOptions } from './markdown.service';

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -3,7 +3,7 @@ import { ComponentRef, EmbeddedViewRef, SecurityContext, TemplateRef, ViewContai
 import { TestBed } from '@angular/core/testing';
 import { BrowserModule, DomSanitizer } from '@angular/platform-browser';
 import { marked } from 'marked';
-import { first } from 'rxjs';
+import { first } from 'rxjs/operators';
 
 import { ClipboardButtonComponent } from './clipboard-button.component';
 import { KatexOptions } from './katex-options';

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gumshoejs": "^5.1.2",
     "hammerjs": "~2.0.8",
     "ngx-markdown": "file:./lib",
-    "rxjs": "~7.5.0",
+    "rxjs": "~6.5.3",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8616,12 +8616,19 @@ rxjs@6.6.7, rxjs@^6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.5.5, rxjs@~7.5.0:
+rxjs@^7.5.5:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
     tslib "^2.1.0"
+
+rxjs@~6.5.3:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
+  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"


### PR DESCRIPTION
### Bug fixes
- Fix backward compatibility for `rxjs` version `^6.5.3`

Fix #397, #398