### PR TITLE
marked should be peerDependency

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -31,7 +31,6 @@
     "clipboard": "^2.0.11",
     "emoji-toolkit": "^6.6.0",
     "katex": "^0.16.0",
-    "marked": "^4.0.17",
     "mermaid": "^9.1.2",
     "prismjs": "^1.28.0",
     "tslib": "^2.3.0"
@@ -40,6 +39,7 @@
     "@angular/common": "^14.0.0",
     "@angular/core": "^14.0.0",
     "@angular/platform-browser": "^14.0.0",
+    "marked": "^4.0.17",
     "rxjs": "^6.5.3 || ^7.4.0",
     "zone.js": "^0.11.4"
   }


### PR DESCRIPTION
In our app we use both ngx-markdown and marked (plain version).

When we import plain marked, it makes `marked.esm.js` appear 2 times in our bundle.  Please move the "marked" to peerDependency of your package.json.

See here the screen shot from webpack-bundle-analyzer
<img width="854" alt="image" src="https://user-images.githubusercontent.com/2387520/185975494-cb38f3d3-7bb0-4c38-90f9-1f9588369848.png">
