### PR TITLE
Update Emoji-Toolkit to v7.0.0

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -40,7 +40,7 @@
   },
   "optionalDependencies": {
     "clipboard": "^2.0.11",
-    "emoji-toolkit": "^6.6.0",
+    "emoji-toolkit": "^7.0.0",
     "katex": "^0.16.0",
     "mermaid": "^9.1.2",
     "prismjs": "^1.28.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/platform-browser-dynamic": "^15.0.0",
     "@angular/router": "^15.0.0",
     "clipboard": "^2.0.11",
-    "emoji-toolkit": "^6.6.0",
+    "emoji-toolkit": "^7.0.0",
     "gumshoejs": "^5.1.2",
     "hammerjs": "~2.0.8",
     "katex": "^0.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4638,10 +4638,10 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emoji-toolkit@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/emoji-toolkit/-/emoji-toolkit-6.6.0.tgz#e7287c43a96f940ec4c5428cd7100a40e57518f1"
-  integrity sha512-pEu0kow2p1N8zCKnn/L6H0F3rWUBB3P3hVjr/O5yl1fK7N9jU4vO4G7EFapC5Y3XwZLUCY0FZbOPyTkH+4V2eQ==
+emoji-toolkit@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-toolkit/-/emoji-toolkit-7.0.0.tgz#63b5e5bdc63acd2e5629a0157969b94d414961fb"
+  integrity sha512-swoVbGlR/cyJ2ysrw1+axjRkEHAlH0myhbK1ybkv8zR6r9KpL4vzb96m3Y2j0hixUKj1Nb8YBQbk3ihB+XkpBw==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -7638,9 +7638,11 @@ ng-packagr@^15.0.0:
 
 "ngx-markdown@file:lib":
   version "15.0.0-next.0"
+  dependencies:
+    tslib "^2.3.0"
   optionalDependencies:
     clipboard "^2.0.11"
-    emoji-toolkit "^6.6.0"
+    emoji-toolkit "^7.0.0"
     katex "^0.16.0"
     mermaid "^9.1.2"
     prismjs "^1.28.0"
@@ -8310,9 +8312,9 @@ postcss-modules-values@^4.0.0:
     icss-utils "^5.0.0"
 
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
-  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz#2e41dc39b7ad74046e1615185185cd0b17d0c8dc"
+  integrity sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"


### PR DESCRIPTION
### New features and enhancements

Update `emoji-toolkit` optional dependency to [v7.0.0](https://github.com/joypixels/emoji-toolkit/releases/tag/7.0.0) to support [Unicode 14](https://emojipedia.org/unicode-14.0/).

