### PR TITLE
Add option to disable sanitizer in both component and pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,25 @@ MarkdownModule.forRoot({
 
 > :blue_book: Follow [Angular DomSanitizer](https://angular.io/api/platform-browser/DomSanitizer#sanitize) documentation for more information on sanitization and security contexts.
 
+You can bypass sanitization using the markdown component, directive or pipe using the `disableSanitizer` option as follow:
+
+```html
+<!-- disable sanitizer using markdown component -->
+<markdown
+  [data]="markdown"
+  [disableSanitizer]="true">
+</markdown>
+
+<!-- disable sanitizer using markdown directive -->
+<div markdown
+  [data]="markdown"
+  [disableSanitizer]="true">
+</div>
+
+<!-- disable sanitizer using markdown pipe -->
+<div [innerHTML]="markdown | markdown : { disableSanitizer: true }"></div>
+```
+
 #### MarkedOptions
 
 Optionally, markdown parsing can be configured by passing [MarkedOptions](https://marked.js.org/#/USING_ADVANCED.md#options) to the `forRoot` method of `MarkdownModule`.
@@ -727,6 +746,7 @@ export interface MarkdownPipeOptions {
   mermaid?: boolean;
   mermaidOptions?: MermaidAPI.Config;
   markedOptions?: MarkedOptions;
+  disableSanitizer?: boolean;
 }
 ```
 

--- a/lib/src/markdown.component.spec.ts
+++ b/lib/src/markdown.component.spec.ts
@@ -191,6 +191,7 @@ describe('MarkdownComponent', () => {
       component.inline = true;
       component.emoji = false;
       component.mermaid = false;
+      component.disableSanitizer = true;
       component.render(raw, true);
 
       expect(markdownService.parse).toHaveBeenCalledWith(raw, {
@@ -198,6 +199,7 @@ describe('MarkdownComponent', () => {
         inline: true,
         emoji: false,
         mermaid: false,
+        disableSanitizer: true,
       });
     });
 
@@ -312,6 +314,7 @@ describe('MarkdownComponent', () => {
         inline: false,
         emoji: false,
         mermaid: true,
+        disableSanitizer: false,
       });
 
       expect(markdownService.render).toHaveBeenCalledWith(

--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -39,6 +39,10 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
   @Input() src: string | undefined;
 
   @Input()
+  get disableSanitizer(): boolean { return this._inline; }
+  set disableSanitizer(value: boolean) { this._inline = this.coerceBooleanProperty(value); }
+
+  @Input()
   get inline(): boolean { return this._inline; }
   set inline(value: boolean) { this._inline = this.coerceBooleanProperty(value); }
 
@@ -147,6 +151,7 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
       inline: this.inline,
       emoji: this.emoji,
       mermaid: this.mermaid,
+      disableSanitizer: this.disableSanitizer,
     };
 
     const renderOptions: RenderOptions = {

--- a/lib/src/markdown.pipe.spec.ts
+++ b/lib/src/markdown.pipe.spec.ts
@@ -84,7 +84,7 @@ describe('MarkdownPipe', () => {
     const markdown = '# Markdown';
     const mockParsed = 'compiled-x';
     const mockBypassSecurity = 'bypass-x';
-    const mockPipeOptions: MarkdownPipeOptions = { inline: true, emoji: true };
+    const mockPipeOptions: MarkdownPipeOptions = { inline: true, emoji: true, disableSanitizer: true };
 
     spyOn(markdownService, 'parse').and.returnValue(mockParsed);
     spyOn(domSanitizer, 'bypassSecurityTrustHtml').and.returnValue(mockBypassSecurity);

--- a/lib/src/markdown.pipe.ts
+++ b/lib/src/markdown.pipe.ts
@@ -35,8 +35,6 @@ export class MarkdownPipe implements PipeTransform {
       .pipe(first())
       .subscribe(() => this.markdownService.render(this.elementRef.nativeElement, options, this.viewContainerRef));
 
-    return options?.disableSanitizer
-      ? markdown
-      : this.domSanitizer.bypassSecurityTrustHtml(markdown);
+    return this.domSanitizer.bypassSecurityTrustHtml(markdown);
   }
 }

--- a/lib/src/markdown.pipe.ts
+++ b/lib/src/markdown.pipe.ts
@@ -35,6 +35,8 @@ export class MarkdownPipe implements PipeTransform {
       .pipe(first())
       .subscribe(() => this.markdownService.render(this.elementRef.nativeElement, options, this.viewContainerRef));
 
-    return this.domSanitizer.bypassSecurityTrustHtml(markdown);
+    return options?.disableSanitizer
+      ? markdown
+      : this.domSanitizer.bypassSecurityTrustHtml(markdown);
   }
 }

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -30,6 +30,7 @@ describe('MarkdowService', () => {
   let domSanitizer: DomSanitizer;
   let http: HttpTestingController;
   let markdownService: MarkdownService;
+  let securityContext: SecurityContext;
   let viewContainerRef: ViewContainerRef;
 
   const viewContainerRefSpy = jasmine.createSpyObj<ViewContainerRef>(['createComponent', 'createEmbeddedView']);
@@ -47,18 +48,36 @@ describe('MarkdowService', () => {
 
         domSanitizer = TestBed.inject(DomSanitizer);
         markdownService = TestBed.inject(MarkdownService);
+        securityContext = TestBed.inject(SECURITY_CONTEXT);
       });
 
-      it('should sanitize parsed markdown', () => {
-
-        const securityContext = TestBed.inject(SECURITY_CONTEXT);
+      it('should sanitize parsed markdown when disableSanitizer is ommited/false/null/undefined', () => {
 
         const mockRaw = '### Markdown-x';
-        const sanitized = domSanitizer.sanitize(securityContext, marked.parse(mockRaw));
+        const sanitized = domSanitizer.sanitize(securityContext, marked.parse(mockRaw))!;
         const unsanitized = marked.parse(mockRaw);
 
-        expect(markdownService.parse(mockRaw, { decodeHtml: false })).toBe(sanitized!);
-        expect(markdownService.parse(mockRaw, { decodeHtml: false })).not.toBe(unsanitized);
+        expect(markdownService.parse(mockRaw)).toBe(sanitized);
+        expect(markdownService.parse(mockRaw)).not.toBe(unsanitized);
+
+        expect(markdownService.parse(mockRaw, { disableSanitizer: false })).toBe(sanitized);
+        expect(markdownService.parse(mockRaw, { disableSanitizer: false })).not.toBe(unsanitized);
+
+        expect(markdownService.parse(mockRaw, { disableSanitizer: null! })).toBe(sanitized);
+        expect(markdownService.parse(mockRaw, { disableSanitizer: null! })).not.toBe(unsanitized);
+
+        expect(markdownService.parse(mockRaw, { disableSanitizer: undefined })).toBe(sanitized);
+        expect(markdownService.parse(mockRaw, { disableSanitizer: undefined })).not.toBe(unsanitized);
+      });
+
+      it('should not sanitize parsed markdown when disableSanitizer is true', () => {
+
+        const mockRaw = '### Markdown-x';
+        const sanitized = domSanitizer.sanitize(securityContext, marked.parse(mockRaw))!;
+        const unsanitized = marked.parse(mockRaw);
+
+        expect(markdownService.parse(mockRaw, { disableSanitizer: true })).not.toBe(sanitized);
+        expect(markdownService.parse(mockRaw, { disableSanitizer: true })).toBe(unsanitized);
       });
     });
   });
@@ -77,8 +96,10 @@ describe('MarkdowService', () => {
         ],
       });
 
+      domSanitizer = TestBed.inject(DomSanitizer);
       http = TestBed.inject(HttpTestingController);
       markdownService = TestBed.inject(MarkdownService);
+      securityContext = TestBed.inject(SECURITY_CONTEXT);
       viewContainerRef = TestBed.inject(ViewContainerRef);
     });
 
@@ -185,7 +206,7 @@ describe('MarkdowService', () => {
         expect(markdownService.parse(mockRaw)).toBe(marked.parse(expected));
       });
 
-      it('should decode HTML correctly when decodeHtml is true ', () => {
+      it('should decode HTML correctly when decodeHtml is true', () => {
 
         const mockRaw = '&lt;html&gt;';
         const expected = '<html>';
@@ -317,9 +338,9 @@ describe('MarkdowService', () => {
       it('should not sanitize parsed markdown', () => {
 
         const mockRaw = '### Markdown-x';
-        const expected = marked.parse(mockRaw);
+        const unsanitized = marked.parse(mockRaw);
 
-        expect(markdownService.parse(mockRaw, { decodeHtml: false })).toBe(expected);
+        expect(markdownService.parse(mockRaw, { decodeHtml: false })).toBe(unsanitized);
       });
     });
 

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -60,6 +60,7 @@ export interface ParseOptions {
   emoji?: boolean;
   mermaid?: boolean;
   markedOptions?: MarkedOptions;
+  disableSanitizer?: boolean;
 }
 
 export interface RenderOptions {
@@ -69,7 +70,6 @@ export interface RenderOptions {
   katexOptions?: KatexOptions;
   mermaid?: boolean;
   mermaidOptions?: MermaidAPI.Config;
-  disableSanitizer?: boolean;
 }
 
 export class ExtendedRenderer extends Renderer {
@@ -85,6 +85,7 @@ export class MarkdownService {
     emoji: false,
     mermaid: false,
     markedOptions: undefined,
+    disableSanitizer: false,
   };
 
   private readonly DEFAULT_RENDER_OPTIONS: RenderOptions = {
@@ -155,6 +156,7 @@ export class MarkdownService {
       emoji,
       mermaid,
       markedOptions = this.options,
+      disableSanitizer,
     } = options;
 
     if (mermaid) {
@@ -165,8 +167,9 @@ export class MarkdownService {
     const decoded = decodeHtml ? this.decodeHtml(trimmed) : trimmed;
     const emojified = emoji ? this.parseEmoji(decoded) : decoded;
     const marked = this.parseMarked(emojified, markedOptions, inline);
+    const sanitized = disableSanitizer ? marked : this.sanitizer.sanitize(this.securityContext, marked);
 
-    return this.sanitizer.sanitize(this.securityContext, marked) || '';
+    return sanitized || '';
   }
 
   render(element: HTMLElement, options: RenderOptions = this.DEFAULT_RENDER_OPTIONS, viewContainerRef?: ViewContainerRef): void {

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -69,6 +69,7 @@ export interface RenderOptions {
   katexOptions?: KatexOptions;
   mermaid?: boolean;
   mermaidOptions?: MermaidAPI.Config;
+  disableSanitizer?: boolean;
 }
 
 export class ExtendedRenderer extends Renderer {


### PR DESCRIPTION
### New features and enhancements

- Add `disableSanitizer: boolean` option as an input property to `MarkdownComponent` and as a parameter to `MarkdownPipe`, allowing to bypass the DOM sanitizer

### Special Thanks

🥇 Thanks to [paviad](https://github.com/paviad) for his contribution to adding the `disableSanitizer` option.

Fix #428 | Replace #429