### PR TITLE
Add support for relative links when using src input property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,10 @@ jobs:
       - browser-tools/install-chromedriver
       # TEMPORARY TO DEBUG ERROR ON CHECKOUT STEP !!!
       - run:
-          name: List directory content
-          command: pwd && ls -ahl
+          name: Remove LICENSE.chromedriver file
+          command: |
+            rm -f LICENSE.chromedriver
+            ls -ahl
       # Checkout the code from the branch into the working_directory
       - checkout
       # Restore dependencies from cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # TEMPORARY TO DEBUG ERROR ON CHECKOUT STEP !!!
       - run:
           name: List directory content
-          command: pwd -W && ls -ahl
+          command: pwd && ls -ahl
       # Checkout the code from the branch into the working_directory
       - checkout
       # Restore dependencies from cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,14 @@ jobs:
       # Install chrome via browser tools
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-      # TEMPORARY TO DEBUG ERROR ON CHECKOUT STEP !!!
+      # Fix CI by removing file added in root directory when installing chromedriver
       - run:
           name: Remove LICENSE.chromedriver file
           command: |
+            echo "Before removing..."
+            ls -ahl
             rm -f LICENSE.chromedriver
+            echo "After removing..."
             ls -ahl
       # Checkout the code from the branch into the working_directory
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # TEMPORARY TO DEBUG ERROR ON CHECKOUT STEP !!!
       - run:
           name: List directory content
-          command: ls home/circleci/project/
+          command: ls -ahl
       # Checkout the code from the branch into the working_directory
       - checkout
       # Restore dependencies from cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.3.0
+  browser-tools: circleci/browser-tools@1.4.1
 jobs:
   build:
     docker:
@@ -9,15 +9,6 @@ jobs:
       # Install chrome via browser tools
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-      # Fix CI by removing file added in root directory when installing chromedriver
-      - run:
-          name: Remove LICENSE.chromedriver file
-          command: |
-            echo "Before removing..."
-            ls -ahl
-            rm -f LICENSE.chromedriver
-            echo "After removing..."
-            ls -ahl
       # Checkout the code from the branch into the working_directory
       - checkout
       # Restore dependencies from cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # TEMPORARY TO DEBUG ERROR ON CHECKOUT STEP !!!
       - run:
           name: List directory content
-          command: ls -ahl
+          command: pwd -W && ls -ahl
       # Checkout the code from the branch into the working_directory
       - checkout
       # Restore dependencies from cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ jobs:
       # Install chrome via browser tools
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
+      # TEMPORARY TO DEBUG ERROR ON CHECKOUT STEP !!!
+      - run:
+          name: List directory content
+          command: ls home/circleci/project/
       # Checkout the code from the branch into the working_directory
       - checkout
       # Restore dependencies from cache

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ https://angular.io/api/core/Component#preserveWhitespaces
 
 ### Component
 
-You can use `markdown` component to either parse static markdown directly from your HTML markup, load the content from a remote URL using `src` property or bind a variable to your component using `data` property. You can get a hook on load complete using `load` output event property, on loading error using `error` output event property or when parsing is completed using `ready` output event property.
+You can use `markdown` component to either parse static markdown directly from your HTML markup, load the content from a remote URL using `src` property or bind a variable to your component using `data` property. To enable relative oath for links/images when using `src` input property to load content remotely, set the `srcRelativeLink` input property to `true`. You can get a hook on load complete using `load` output event property, on loading error using `error` output event property or when parsing is completed using `ready` output event property.
 
 ```html
 <!-- static markdown -->
@@ -652,6 +652,7 @@ You can use `markdown` component to either parse static markdown directly from y
 <!-- loaded from remote url -->
 <markdown
   [src]="'path/to/file.md'"
+  [srcRelativeLink]="true"
   (load)="onLoad($event)"
   (error)="onError($event)">
 </markdown>
@@ -682,6 +683,7 @@ The same way the component works, you can use `markdown` directive to accomplish
 <!-- loaded from remote url -->
 <div markdown
   [src]="'path/to/file.md'"
+  [srcRelativeLink]="true"
   (load)="onLoad($event)"
   (error)="onError($event)">
 </div>

--- a/lib/src/markdown.component.spec.ts
+++ b/lib/src/markdown.component.spec.ts
@@ -198,6 +198,49 @@ describe('MarkdownComponent', () => {
         inline: true,
         emoji: false,
         mermaid: false,
+        markedOptions: undefined,
+      });
+    });
+
+    it('should parse markdown with markedOptions.baseUrl when src is provided and srcRelativeLink is true', () => {
+      const raw = '### Raw';
+
+      spyOn(markdownService, 'parse');
+
+      component.src = './src-example/file.md';
+      component.srcRelativeLink = true;
+      component.inline = true;
+      component.emoji = false;
+      component.mermaid = false;
+      component.render(raw, true);
+
+      expect(markdownService.parse).toHaveBeenCalledWith(raw, {
+        decodeHtml: true,
+        inline: true,
+        emoji: false,
+        mermaid: false,
+        markedOptions: { baseUrl: '/src-example/file.md' },
+      });
+    });
+
+    it('should parse markdown without markedOptions.baseUrl when src is provided and srcRelativeLink is false', () => {
+      const raw = '### Raw';
+
+      spyOn(markdownService, 'parse');
+
+      component.src = './src-example/file.md';
+      component.srcRelativeLink = false;
+      component.inline = true;
+      component.emoji = false;
+      component.mermaid = false;
+      component.render(raw, true);
+
+      expect(markdownService.parse).toHaveBeenCalledWith(raw, {
+        decodeHtml: true,
+        inline: true,
+        emoji: false,
+        mermaid: false,
+        markedOptions: undefined,
       });
     });
 
@@ -312,6 +355,7 @@ describe('MarkdownComponent', () => {
         inline: false,
         emoji: false,
         mermaid: true,
+        markedOptions: undefined,
       });
 
       expect(markdownService.render).toHaveBeenCalledWith(

--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -44,8 +44,8 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
   set inline(value: boolean) { this._inline = this.coerceBooleanProperty(value); }
 
   @Input()
-  get useBaseUrl(): boolean { return this._useBaseUrl; }
-  set useBaseUrl(value: boolean) { this._useBaseUrl = this.coerceBooleanProperty(value); }
+  get srcRelativeLink(): boolean { return this._srcRelativeLink; }
+  set srcRelativeLink(value: boolean) { this._srcRelativeLink = this.coerceBooleanProperty(value); }
 
   // Plugin - clipboard
   @Input()
@@ -107,7 +107,7 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
   private _lineHighlight = false;
   private _lineNumbers = false;
   private _mermaid = false;
-  private _useBaseUrl = false;
+  private _srcRelativeLink = false;
 
   private readonly destroyed$ = new Subject<void>();
 
@@ -149,7 +149,7 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
 
   render(markdown: string, decodeHtml = false): void {
     let markedOptions: MarkedOptions | undefined;
-    if (this.useBaseUrl && this.src) {
+    if (this.src && this.srcRelativeLink) {
       const baseUrl = new URL(this.src, location.origin).pathname;
       markedOptions = { baseUrl };
     }

--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -37,6 +37,7 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
 
   @Input() data: string | undefined;
   @Input() src: string | undefined;
+  @Input() enableBasePath: boolean;
 
   @Input()
   get inline(): boolean { return this._inline; }
@@ -109,7 +110,10 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
     public element: ElementRef<HTMLElement>,
     public markdownService: MarkdownService,
     public viewContainerRef: ViewContainerRef,
-  ) { }
+  ) {
+    // default to false...  override by setting [enableBasePath]="true" in HTML element
+    this.enableBasePath = false;
+  }
 
   ngOnChanges(): void {
     this.loadContent();
@@ -161,7 +165,11 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
       mermaidOptions: this.mermaidOptions,
     };
 
-    const parsed = this.markdownService.parse(markdown, parsedOptions);
+    const useBasePath = this.enableBasePath && this.src;
+    const baseUrl = this.src ? new URL(this.src, location.origin).pathname : '';
+    const parsed = !useBasePath
+      ? this.markdownService.parse(markdown, parsedOptions)
+      : this.markdownService.parse(markdown, parsedOptions, { baseUrl });
 
     this.element.nativeElement.innerHTML = parsed;
 

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -17,8 +17,10 @@ import {
   errorKatexNotLoaded,
   errorMermaidNotLoaded,
   MarkdownService,
+  ParseOptions,
   SECURITY_CONTEXT,
 } from './markdown.service';
+import { MarkedOptions } from './marked-options';
 import { MermaidAPI } from './mermaid-options';
 
 declare let window: any;
@@ -304,6 +306,32 @@ describe('MarkdowService', () => {
 
         useCases.forEach(func => {
           expect(func()).toBe(marked.parse(mockRaw));
+        });
+      });
+
+      it('should provide markedOptions correctly when parsing', () => {
+
+        const mockRaw = '### Markdown-x';
+        const mockMarkedOptions: MarkedOptions = {
+          baseUrl: 'mock-base-url',
+          breaks: true,
+          gfm: false,
+          headerIds: true,
+          smartypants: true,
+        };
+        const parseOptions: ParseOptions = {
+          markedOptions: mockMarkedOptions,
+        };
+
+        const markedParseSpy = spyOn(marked, 'parse');
+
+        markdownService.parse(mockRaw, parseOptions);
+
+        expect(markedParseSpy).toHaveBeenCalled();
+        expect(markedParseSpy.calls.argsFor(0)[0]).toBe(mockRaw);
+        expect(markedParseSpy.calls.argsFor(0)[1]).toEqual({
+          ...markdownService.options,
+          ...mockMarkedOptions,
         });
       });
 

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -147,14 +147,23 @@ export class MarkdownService {
     this.options = options;
   }
 
-  parse(markdown: string, options: ParseOptions = this.DEFAULT_PARSE_OPTIONS): string {
+  parse(
+    markdown: string,
+    options: ParseOptions = this.DEFAULT_PARSE_OPTIONS,
+    markedOptionsFromComponent?: MarkedOptions,
+  ): string {
     const {
       decodeHtml,
       inline,
       emoji,
       mermaid,
-      markedOptions = this.options,
+      markedOptions: markedOptionsFromService,
     } = options;
+
+    const markedOptions = {
+      ...(markedOptionsFromService ?? {}),
+      ...(markedOptionsFromComponent ?? {}),
+    };
 
     if (mermaid) {
       this.renderer = this.extendRenderer(markedOptions.renderer || new Renderer());

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -78,23 +78,6 @@ export class ExtendedRenderer extends Renderer {
 @Injectable()
 export class MarkdownService {
 
-  private readonly DEFAULT_PARSE_OPTIONS: ParseOptions = {
-    decodeHtml: false,
-    inline: false,
-    emoji: false,
-    mermaid: false,
-    markedOptions: undefined,
-  };
-
-  private readonly DEFAULT_RENDER_OPTIONS: RenderOptions = {
-    clipboard: false,
-    clipboardOptions: undefined,
-    katex: false,
-    katexOptions: undefined,
-    mermaid: false,
-    mermaidOptions: undefined,
-  };
-
   private readonly DEFAULT_MARKED_OPTIONS: MarkedOptions = {
     renderer: new MarkedRenderer(),
   };
@@ -119,6 +102,23 @@ export class MarkdownService {
 
   private readonly DEFAULT_CLIPBOARD_OPTIONS: ClipboardOptions = {
     buttonComponent: undefined,
+  };
+
+  private readonly DEFAULT_PARSE_OPTIONS: ParseOptions = {
+    decodeHtml: false,
+    inline: false,
+    emoji: false,
+    mermaid: false,
+    markedOptions: this.DEFAULT_MARKED_OPTIONS,
+  };
+
+  private readonly DEFAULT_RENDER_OPTIONS: RenderOptions = {
+    clipboard: false,
+    clipboardOptions: undefined,
+    katex: false,
+    katexOptions: undefined,
+    mermaid: false,
+    mermaidOptions: undefined,
   };
 
   private _options: MarkedOptions | undefined;
@@ -147,22 +147,17 @@ export class MarkdownService {
     this.options = options;
   }
 
-  parse(
-    markdown: string,
-    options: ParseOptions = this.DEFAULT_PARSE_OPTIONS,
-    markedOptionsFromComponent?: MarkedOptions,
-  ): string {
+  parse(markdown: string, parseOptions: ParseOptions = this.DEFAULT_PARSE_OPTIONS): string {
     const {
       decodeHtml,
       inline,
       emoji,
       mermaid,
-      markedOptions: markedOptionsFromService,
-    } = options;
+    } = parseOptions;
 
     const markedOptions = {
-      ...(markedOptionsFromService ?? {}),
-      ...(markedOptionsFromComponent ?? {}),
+      ...this.options,
+      ...parseOptions.markedOptions,
     };
 
     if (mermaid) {


### PR DESCRIPTION
### New features and enhancements

- Add `srcRelativeLink: boolean` input property to `MarkdownComponent` to support relative links for remotely loaded markdown (default is `false`)

### Special Thanks

🥇 Thanks to [datumgeek](https://github.com/datumgeek) for his contribution to adding the `srcRelativeLink` option.

Fix #227 | Replace #417, #228