### PR TITLE
Handle null value for data and src input properties

### DIFF
--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -36,8 +36,8 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
   protected static ngAcceptInputType_lineNumbers: boolean | '';
   protected static ngAcceptInputType_commandLine: boolean | '';
 
-  @Input() data: string | undefined;
-  @Input() src: string | undefined;
+  @Input() data: string | null | undefined;
+  @Input() src: string | null | undefined;
 
   @Input()
   get disableSanitizer(): boolean { return this._disableSanitizer; }


### PR DESCRIPTION
### Bug fix
- Fix `data` and `src` input properties type to allow `null` value due to the return type of the `async` pipe output

Fix #433 
