### PR TITLE
feat: allow zone.js v0.13.x

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -36,7 +36,7 @@
     "@types/marked": "^4.0.3",
     "marked": "^4.0.17",
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.11.4 || ~0.12.0"
+    "zone.js": "~0.11.4 || ~0.12.0 || ~0.13.0"
   },
   "optionalDependencies": {
     "clipboard": "^2.0.11",


### PR DESCRIPTION
`zone.js` v0.13.0 was recently released, which should be marked as supported by this library. It was a bug fix only release, so it shouldn't affect this project in any way, see their [changelog](https://github.com/angular/angular/blob/main/packages/zone.js/CHANGELOG.md#013-2023-02-28).