### PR TITLE
Update emoji-toolkit lib to 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Optionally, to automatically present some lines as output without providing the 
 To add [Emoji-Toolkit](https://github.com/joypixels/emoji-toolkit) library to your `package.json` use the following command.
 
 ```bash
-npm install emoji-toolkit@^7.0.0 --save
+npm install emoji-toolkit@^8.0.0 --save
 ```
 
 To activate [Emoji-Toolkit](https://github.com/joypixels/emoji-toolkit) for emoji suppport you will need to include...

--- a/lib/package.json
+++ b/lib/package.json
@@ -40,7 +40,7 @@
   },
   "optionalDependencies": {
     "clipboard": "^2.0.11",
-    "emoji-toolkit": "^7.0.0",
+    "emoji-toolkit": "^8.0.0",
     "katex": "^0.16.0",
     "mermaid": "^10.6.0",
     "prismjs": "^1.28.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/platform-browser-dynamic": "^16.0.0",
     "@angular/router": "^16.0.0",
     "clipboard": "^2.0.11",
-    "emoji-toolkit": "^7.0.0",
+    "emoji-toolkit": "^8.0.0",
     "gumshoejs": "^5.1.2",
     "hammerjs": "~2.0.8",
     "katex": "^0.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4904,10 +4904,10 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-emoji-toolkit@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/emoji-toolkit/-/emoji-toolkit-7.0.1.tgz"
-  integrity sha512-l5aJyAhpC5s4mDuoVuqt4SzVjwIsIvakPh4ZGJJE4KWuWFCEHaXacQFkStVdD9zbRR+/BbRXob7u99o0lQFr8A==
+emoji-toolkit@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-toolkit/-/emoji-toolkit-8.0.0.tgz#59e0273a4a32d653b5125e9a1b8823f0611a042a"
+  integrity sha512-Vz8YIqQJsQ+QZ4yuKMMzliXceayqfWbNjb6bST+vm77QAhU2is3I+/PRxrNknW+q1bvHHMgjLCQXxzINWLVapg==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -8146,7 +8146,7 @@ ng-packagr@^16.0.0:
     tslib "^2.3.0"
   optionalDependencies:
     clipboard "^2.0.11"
-    emoji-toolkit "^7.0.0"
+    emoji-toolkit "^8.0.0"
     katex "^0.16.0"
     mermaid "^10.6.0"
     prismjs "^1.28.0"


### PR DESCRIPTION
### New features and enhancements

- Update `emoji-toolkit` to 8.0.0 to support unicode 15.0