### PR TITLE
Fix custom renderer gets overridden when using MarkdownPipe

### DIFF
--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -22,6 +22,7 @@ import {
   SECURITY_CONTEXT,
 } from './markdown.service';
 import { MarkedOptions } from './marked-options';
+import { MarkedRenderer } from './marked-renderer';
 import { MermaidAPI } from './mermaid-options';
 
 declare let window: any;
@@ -389,6 +390,22 @@ describe('MarkdownService', () => {
         expect(markedParseSpy).toHaveBeenCalled();
         expect(markedParseSpy.calls.argsFor(0)[0]).toBe(mockRaw);
         expect(markedParseSpy.calls.argsFor(0)[1]).toEqual(expectedOptions);
+      });
+
+      it('should not override markedOptions.renderer when parsing and parseOptions.renderer is not provided', () => {
+
+        const mockRaw = '### Markdown-x';
+        const mockRenderer = new MarkedRenderer();
+        mockRenderer.blockquote = () => 'mock-blocquote';
+        const mockMarkedOptions: MarkedOptions = { breaks: true, gfm: false, pedantic: true, silent: false, renderer: mockRenderer };
+
+        const markedUseSpy = spyOn(marked, 'use');
+
+        markdownService.options = mockMarkedOptions;
+        markdownService.parse(mockRaw);
+
+        expect(markedUseSpy).toHaveBeenCalled();
+        expect(markedUseSpy).toHaveBeenCalledWith({ renderer: mockRenderer });
       });
 
       it('should return empty string when raw is null/undefined/empty', () => {

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -121,7 +121,7 @@ export class MarkdownService {
     inline: false,
     emoji: false,
     mermaid: false,
-    markedOptions: this.DEFAULT_MARKED_OPTIONS,
+    markedOptions: undefined,
     disableSanitizer: false,
   };
 


### PR DESCRIPTION
### Bug Fixes

- Fix custom renderer gets overridden when using MarkdownPipe

Fix #456 