### PR TITLE
Relax provideMarkdown method usage to not require environment provider

### DIFF
--- a/lib/src/provide-markdown.ts
+++ b/lib/src/provide-markdown.ts
@@ -3,7 +3,7 @@ import { MarkdownModuleConfig } from './markdown.module';
 import { MarkdownService, SECURITY_CONTEXT } from './markdown.service';
 import { MARKED_EXTENSIONS } from './marked-extensions';
 
-export function provideMarkdown(markdownModuleConfig?: MarkdownModuleConfig): Provider {
+export function provideMarkdown(markdownModuleConfig?: MarkdownModuleConfig): Provider[] {
   return [
     MarkdownService,
     markdownModuleConfig?.loader ?? [],

--- a/lib/src/provide-markdown.ts
+++ b/lib/src/provide-markdown.ts
@@ -1,10 +1,10 @@
-import { EnvironmentProviders, makeEnvironmentProviders, SecurityContext } from '@angular/core';
+import { Provider, SecurityContext } from '@angular/core';
 import { MarkdownModuleConfig } from './markdown.module';
 import { MarkdownService, SECURITY_CONTEXT } from './markdown.service';
 import { MARKED_EXTENSIONS } from './marked-extensions';
 
-export function provideMarkdown(markdownModuleConfig?: MarkdownModuleConfig): EnvironmentProviders {
-  return makeEnvironmentProviders([
+export function provideMarkdown(markdownModuleConfig?: MarkdownModuleConfig): Provider {
+  return [
     MarkdownService,
     markdownModuleConfig?.loader ?? [],
     markdownModuleConfig?.clipboardOptions ?? [],
@@ -17,5 +17,5 @@ export function provideMarkdown(markdownModuleConfig?: MarkdownModuleConfig): En
       provide: SECURITY_CONTEXT,
       useValue: markdownModuleConfig?.sanitize ?? SecurityContext.HTML,
     },
-  ]);
+  ];
 }


### PR DESCRIPTION
It looks like the fix is as simple as adjusting the definition of `provideMarkdown` to not have the call to `makeEnvironmentProviders`.

It looks like this method is meant to enforce a rule that the provider only be usable in root, but that's not required. By relaxing this requirement I was able to move the `provideMarkdown` call into the component itself instead of the `app.config.ts` file.

To prove my theory,
As part of my testing of the demo app, this allowed the `marked` dep to not be part of the initial page bundle, effectively allowing for ~90 KB reduction from `marked`, `github-slugger`, and some `rxjs` dependences used in the app demo.

Before:
<img width="1421" alt="image" src="https://github.com/jfcere/ngx-markdown/assets/130445/9083b048-c4dc-4d92-ac13-228f4121cea4">

After:
<img width="1420" alt="image" src="https://github.com/jfcere/ngx-markdown/assets/130445/381913b5-6d32-4fe6-a161-aac236a29be7">

**NOTE**: for simplicity, this PR is targeted to only update the `provideMarkdown` method and does not change any tests or code in the `demo` dir.

--- 
Fixes #489