### PR TITLE
Fix globally imported CLIPBOARD_OPTIONS (#529)

### DIFF
--- a/lib/src/markdown.component.ts
+++ b/lib/src/markdown.component.ts
@@ -163,8 +163,8 @@ export class MarkdownComponent implements OnChanges, AfterViewInit, OnDestroy {
     const renderOptions: RenderOptions = {
       clipboard: this.clipboard,
       clipboardOptions: {
-        buttonComponent: this.clipboardButtonComponent,
-        buttonTemplate: this.clipboardButtonTemplate,
+        ...(this.clipboardButtonComponent && { buttonComponent: this.clipboardButtonComponent }),
+        ...(this.clipboardButtonTemplate && { buttonTemplate: this.clipboardButtonTemplate }),
       },
       katex: this.katex,
       katexOptions: this.katexOptions,


### PR DESCRIPTION
Add `buttonComponent` and `buttonTemplate` attributes from template conditionally (only when defined), to not overwrite globally defined values.