### PR TITLE
upgraded mermaid dependency

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -41,7 +41,7 @@
     "clipboard": "^2.0.11",
     "emoji-toolkit": "^8.0.0",
     "katex": "^0.16.0",
-    "mermaid": "^10.6.0",
+    "mermaid": "^11.2.1",
     "prismjs": "^1.28.0"
   },
   "sideEffects": false

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "katex": "^0.16.2",
     "marked": "^12.0.0",
     "marked-gfm-heading-id": "^3.1.3",
-    "mermaid": "^10.6.0",
+    "mermaid": "^11.2.1",
     "ngx-markdown": "file:lib",
     "prismjs": "^1.29.0",
     "rxjs": "~6.5.3",


### PR DESCRIPTION

Issue - https://github.com/jfcere/ngx-markdown/issues/535

This upgrade is very much needed. The issue with mermaid v10 is that it has elkjs as a dependency which has a copyleft license.
