### PR TITLE
refactor: remove `AsyncPipe` to reduce bundle size

### DIFF
--- a/lib/src/clipboard-button.component.ts
+++ b/lib/src/clipboard-button.component.ts
@@ -1,7 +1,7 @@
-import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { merge, of, Subject, timer } from 'rxjs';
-import { distinctUntilChanged, map, mapTo, shareReplay, startWith, switchMap } from 'rxjs/operators';
+import { distinctUntilChanged, mapTo, shareReplay, switchMap } from 'rxjs/operators';
 
 const BUTTON_TEXT_COPY = 'Copy';
 const BUTTON_TEXT_COPIED = 'Copied';
@@ -11,32 +11,30 @@ const BUTTON_TEXT_COPIED = 'Copied';
   template: `
     <button
       class="markdown-clipboard-button"
-      [class.copied]="copied$ | async"
+      [class.copied]="copied()"
       (click)="onCopyToClipboardClick()"
-    >{{ copiedText$ | async }}</button>
+    >{{ copiedText() }}</button>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AsyncPipe],
 })
 export class ClipboardButtonComponent {
-
   private _buttonClick$ = new Subject<void>();
 
-  readonly copied$ = this._buttonClick$.pipe(
-    switchMap(() => merge(
-      of(true),
-      timer(3000).pipe(mapTo(false)),
-    )),
-    distinctUntilChanged(),
-    shareReplay(1),
+  readonly copied = toSignal(
+    this._buttonClick$.pipe(
+      switchMap(() => merge(
+        of(true),
+        timer(3000).pipe(mapTo(false)),
+      )),
+      distinctUntilChanged(),
+      shareReplay(1),
+    )
   );
 
-  readonly copiedText$ = this.copied$.pipe(
-    startWith(false),
-    map(copied => copied
-      ? BUTTON_TEXT_COPIED
-      : BUTTON_TEXT_COPY),
-  );
+  readonly copiedText = computed(() => {
+    const copied = this.copied();
+    return copied ? BUTTON_TEXT_COPIED : BUTTON_TEXT_COPY;
+  });
 
   onCopyToClipboardClick(): void {
     this._buttonClick$.next();

--- a/lib/src/markdown.module.ts
+++ b/lib/src/markdown.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { InjectionToken, ModuleWithProviders, NgModule, Provider, SecurityContext } from '@angular/core';
 import { MarkedExtension } from 'marked';
 import { ClipboardButtonComponent } from './clipboard-button.component';
@@ -66,7 +65,7 @@ const sharedDeclarations = [
 ];
 
 @NgModule({
-  imports: [CommonModule, ...sharedDeclarations],
+  imports: sharedDeclarations,
   exports: sharedDeclarations,
 })
 export class MarkdownModule {


### PR DESCRIPTION
This commit removes the `AsyncPipe` from the bundle and replaces its usage with signals (currently the primary communication mechanism with the view in Angular).

**Use case:** We're using `ngx-markdown`, but not using `AsyncPipe` directly. However, it’s still being included in the initial bundle due to its usage within `ngx-markdown`.