### PR TITLE
docs(README.md): remove useless dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ StackBlitz available @ [https://stackblitz.com/edit/ngx-markdown](https://stackb
 
 ### ngx-markdown
 
-To add ngx-markdown along with the required marked library to your `package.json` use the following commands.
+To add ngx-markdown to your `package.json` use the following commands.
 
 ```bash
-npm install ngx-markdown marked@^15.0.0 --save
+npm install ngx-markdown --save
 ```
 
 ### Syntax highlight


### PR DESCRIPTION
As peerDependencies are automatically downloaded, this is not required to be part of the `npm i` scripts. 

It is also preferable to let it out, as :
if a user would like to remove `ngx-markdown` the `marked` library will be removed automatically, but not if installed manually.

It will also make library upload easier to manage, as the marked will be updated automatically