### PR TITLE
refactor!: Remove MarkdownModuleConfig.sanitize deprecated type

### DIFF
--- a/lib/src/markdown.module.spec.ts
+++ b/lib/src/markdown.module.spec.ts
@@ -202,7 +202,7 @@ describe('MarkdownModule', () => {
 
       TestBed.configureTestingModule({
         imports: [
-          MarkdownModule.forRoot({ sanitize: SecurityContext.NONE }),
+          MarkdownModule.forRoot({ sanitize: { provide: SANITIZE, useValue: SecurityContext.NONE } }),
         ],
       });
 
@@ -211,7 +211,7 @@ describe('MarkdownModule', () => {
       expect(sanitize).toBe(SecurityContext.NONE);
     });
 
-    it('should provide default SecurityContext when MarkdownModuleConfig is provided without sanitize', () => {
+    it('should not provide SecurityContext when MarkdownModuleConfig is provided without sanitize', () => {
 
       TestBed.configureTestingModule({
         imports: [
@@ -224,12 +224,12 @@ describe('MarkdownModule', () => {
         ],
       });
 
-      const sanitize = TestBed.inject(SANITIZE);
+      const sanitize = TestBed.inject(SANITIZE, null, { optional: true });
 
-      expect(sanitize).toBe(SecurityContext.HTML);
+      expect(sanitize).toBeNull();
     });
 
-    it('should provide default SecurityContext when MarkdownModuleConfig is not provided', () => {
+    it('should not provide SecurityContext when MarkdownModuleConfig is not provided', () => {
 
       TestBed.configureTestingModule({
         imports: [
@@ -237,9 +237,9 @@ describe('MarkdownModule', () => {
         ],
       });
 
-      const sanitize = TestBed.inject(SANITIZE);
+      const sanitize = TestBed.inject(SANITIZE, null, { optional: true });
 
-      expect(sanitize).toBe(SecurityContext.HTML);
+      expect(sanitize).toBeNull();
     });
   });
 
@@ -264,7 +264,7 @@ describe('MarkdownModule', () => {
             loader: HttpClient,
             clipboardOptions: { provide: CLIPBOARD_OPTIONS, useValue: mockClipboardOptions },
             markedOptions: { provide: MARKED_OPTIONS, useValue: mockMarkedOptions },
-            sanitize: SecurityContext.NONE,
+            sanitize: { provide: SANITIZE, useValue: SecurityContext.NONE },
           }),
           MarkdownModule.forChild(),
         ],

--- a/lib/src/markdown.module.ts
+++ b/lib/src/markdown.module.ts
@@ -1,4 +1,4 @@
-import { InjectionToken, ModuleWithProviders, NgModule, Provider, SecurityContext } from '@angular/core';
+import { InjectionToken, ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { ClipboardButtonComponent } from './clipboard-button.component';
 import { CLIPBOARD_OPTIONS } from './clipboard-options';
 import { LanguagePipe } from './language.pipe';
@@ -27,24 +27,6 @@ type TypedProvider<T extends InjectionToken<any>> = TypedValueProvider<T> | Type
 
 type MultiTypedProvider<T extends InjectionToken<any>> = TypedProvider<T> & { multi: true };
 
-export function isTypedProvider<T extends InjectionToken<any>>(provider: any): provider is TypedProvider<T> {
-  return provider != null && provider.provide != null;
-}
-
-export function getSanitizeProvider(sanitize: MarkdownModuleConfig['sanitize']): Provider | undefined {
-  return isTypedProvider(sanitize)
-    ? sanitize
-    : { provide: SANITIZE, useValue: sanitize ?? SecurityContext.HTML };
-}
-
-/**
- * @deprecated Will be removed in ngx-markdown v21, use provider syntax instead.
- * ```typescript
- * sanitize: { provide: SANITIZE, useValue: SecurityContext.HTML },
- * ```
- */
-type SanitizeTokenType = InjectionTokenType<typeof SANITIZE>;
-
 // having a dependency on `HttpClientModule` within a library
 // breaks all the interceptors from the app consuming the library
 // here, we explicitely ask the user to pass a provider with
@@ -55,7 +37,7 @@ export interface MarkdownModuleConfig {
   markedOptions?: TypedProvider<typeof MARKED_OPTIONS>;
   markedExtensions?: MultiTypedProvider<typeof MARKED_EXTENSIONS>[];
   mermaidOptions?: TypedProvider<typeof MERMAID_OPTIONS>;
-  sanitize?: SanitizeTokenType | TypedProvider<typeof SANITIZE>;
+  sanitize?: TypedProvider<typeof SANITIZE>;
 }
 
 const sharedDeclarations = [

--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -36,7 +36,7 @@ describe('MarkdownService', () => {
   let domSanitizer: DomSanitizer;
   let http: HttpTestingController;
   let markdownService: MarkdownService;
-  let sanitize: SecurityContext | SanitizeFunction;
+  let sanitize: SecurityContext | SanitizeFunction | null;
   let viewContainerRef: ViewContainerRef;
 
   const mockExtensions = [
@@ -44,6 +44,34 @@ describe('MarkdownService', () => {
     { name: 'mock-extension-two' } as MarkedExtension,
   ];
   const viewContainerRefSpy = jasmine.createSpyObj<ViewContainerRef>(['createComponent', 'createEmbeddedView']);
+
+  describe('without sanitize provider', () => {
+
+    describe('parse', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [
+            MarkdownModule.forRoot(),
+          ],
+        });
+
+        domSanitizer = TestBed.inject(DomSanitizer);
+        markdownService = TestBed.inject(MarkdownService);
+        sanitize = TestBed.inject(SANITIZE, null, { optional: true });
+      });
+
+      it('should sanitize parsed markdown using default HTML security context', async () => {
+
+        const mockRaw = '### Markdown-x';
+        const sanitized = domSanitizer.sanitize(SecurityContext.HTML, await marked.parse(mockRaw))!;
+        const unsanitized = await marked.parse(mockRaw);
+
+        expect(sanitize).toBeNull();
+        expect(await markdownService.parse(mockRaw)).toBe(sanitized);
+        expect(await markdownService.parse(mockRaw)).not.toBe(unsanitized);
+      });
+    });
+  });
 
   describe('with sanitize function', () => {
 
@@ -55,7 +83,7 @@ describe('MarkdownService', () => {
 
         TestBed.configureTestingModule({
           imports: [
-            MarkdownModule.forRoot({ sanitize: sanitizeFuncSpy }),
+            MarkdownModule.forRoot({ sanitize: { provide: SANITIZE, useValue: sanitizeFuncSpy } }),
           ],
         });
 
@@ -89,7 +117,7 @@ describe('MarkdownService', () => {
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [
-            MarkdownModule.forRoot({ sanitize: SecurityContext.HTML }),
+            MarkdownModule.forRoot({ sanitize: { provide: SANITIZE, useValue: SecurityContext.HTML } }),
           ],
         });
 
@@ -141,7 +169,7 @@ describe('MarkdownService', () => {
               { provide: MARKED_EXTENSIONS, useValue: mockExtensions[0], multi: true },
               { provide: MARKED_EXTENSIONS, useFactory: () => mockExtensions[1], multi: true },
             ],
-            sanitize: SecurityContext.NONE,
+            sanitize: { provide: SANITIZE, useValue: SecurityContext.NONE },
           }),
         ],
         providers: [

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -80,7 +80,7 @@ export class MarkdownService {
   private http = inject(HttpClient, { optional: true });
   private mermaidOptions = inject(MERMAID_OPTIONS, { optional: true });
   private platform = inject(PLATFORM_ID);
-  private sanitize = inject(SANITIZE);
+  private sanitize = inject(SANITIZE, { optional: true });
   private sanitizer = inject(DomSanitizer);
 
   private readonly DEFAULT_MARKED_OPTIONS: MarkedOptions = {
@@ -126,6 +126,8 @@ export class MarkdownService {
     mermaid: false,
     mermaidOptions: undefined,
   };
+
+  private readonly DEFAULT_SECURITY_CONTEXT = SecurityContext.HTML;
 
   private _options: MarkedOptions | null = null;
 
@@ -462,7 +464,7 @@ export class MarkdownService {
       return this.sanitize(await html);
     }
     if (this.sanitize !== SecurityContext.NONE) {
-      return this.sanitizer.sanitize(this.sanitize, html) ?? '';
+      return this.sanitizer.sanitize(this.sanitize ?? this.DEFAULT_SECURITY_CONTEXT, html) ?? '';
     }
     return html;
   }

--- a/lib/src/provide-markdown.ts
+++ b/lib/src/provide-markdown.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@angular/core';
-import { getSanitizeProvider, MarkdownModuleConfig } from './markdown.module';
+import { MarkdownModuleConfig } from './markdown.module';
 import { MarkdownService } from './markdown.service';
 
 export function provideMarkdown(markdownModuleConfig?: MarkdownModuleConfig): Provider[] {
@@ -10,6 +10,6 @@ export function provideMarkdown(markdownModuleConfig?: MarkdownModuleConfig): Pr
     markdownModuleConfig?.markedOptions ?? [],
     markdownModuleConfig?.mermaidOptions ?? [],
     markdownModuleConfig?.markedExtensions ?? [],
-    getSanitizeProvider(markdownModuleConfig?.sanitize) ?? [],
+    markdownModuleConfig?.sanitize ?? [],
   ];
 }

--- a/lib/src/sanitize-options.ts
+++ b/lib/src/sanitize-options.ts
@@ -4,6 +4,6 @@ export const SANITIZE = new InjectionToken<SecurityContext | SanitizeFunction>('
 
 export type SanitizeFunction = (html: string) => string;
 
-export function isSanitizeFunction(sanitize: SecurityContext | SanitizeFunction): sanitize is SanitizeFunction {
+export function isSanitizeFunction(sanitize: SecurityContext | SanitizeFunction | null): sanitize is SanitizeFunction {
   return typeof sanitize === 'function';
 }


### PR DESCRIPTION
### New features and enhancements

- Remove direct use of `SecurityContext | SanitizeFunction` type for `MarkdownModuleConfig.sanitize` parameter

### ⚠ Breaking changes

- The configuration property `MarkdownModuleConfig.sanitize` no longer accepts a parameter of type ` SecurityContext | SanitizeFunction` but requires the use of `SANITIZE` injection token instead (see [sanitization](https://github.com/jfcere/ngx-markdown?tab=readme-ov-file#sanitization) for instruction)