### PR TITLE
fix: add support for zone.js 0.16.0

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser": "^21.0.0",
     "marked": "^17.0.0",
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0 || ~0.16.0"
   },
   "optionalDependencies": {
     "clipboard": "^2.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "@angular/platform-browser": "^21.0.0",
         "marked": "^17.0.0",
         "rxjs": "^6.5.3 || ^7.4.0",
-        "zone.js": "~0.15.0"
+        "zone.js": "~0.15.0 || ~0.16.0"
       }
     },
     "node_modules/@algolia/abtesting": {


### PR DESCRIPTION
- Update `zone.js` peer dependency to support `~0.16`