### PR TITLE
Hide optional marked-katex-extension import from Vite

### DIFF
--- a/lib/src/markdown.service.spec.ts
+++ b/lib/src/markdown.service.spec.ts
@@ -259,6 +259,14 @@ describe('MarkdownService', () => {
 
       it('should extend marked renderer when katex is true', async () => {
 
+        const markedKatexSpy = jasmine.createSpy('markedKatex').and.returnValue({
+          extensions: [
+            { name: 'inlineKatex' },
+            { name: 'blockKatex' },
+          ],
+        });
+        markdownService['markedKatex'] = markedKatexSpy;
+
         const markedUseSpy = spyOn(marked, 'use');
 
         await markdownService.parse('### Markdown-x', { katex: true });
@@ -274,6 +282,14 @@ describe('MarkdownService', () => {
       });
 
       it('should not extend marked renderer more than once when katex is true', async () => {
+
+        const markedKatexSpy = jasmine.createSpy('markedKatex').and.returnValue({
+          extensions: [
+            { name: 'inlineKatex' },
+            { name: 'blockKatex' },
+          ],
+        });
+        markdownService['markedKatex'] = markedKatexSpy;
 
         const markedUseSpy = spyOn(marked, 'use');
 
@@ -295,6 +311,14 @@ describe('MarkdownService', () => {
       });
 
       it('should only import marked-katex-extension only once', async () => {
+
+        const markedKatexSpy = jasmine.createSpy('markedKatex').and.returnValue({
+          extensions: [
+            { name: 'inlineKatex' },
+            { name: 'blockKatex' },
+          ],
+        });
+        markdownService['markedKatex'] = markedKatexSpy;
 
         const markedUseSpy = spyOn(marked, 'use');
 

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -264,7 +264,9 @@ export class MarkdownService {
       return renderer;
     }
 
-    this.markedKatex ??= await import('marked-katex-extension')
+    // Hide the optional peer specifier from Vite import-analysis (see #681).
+    const markedKatexSpecifier = 'marked-katex-extension';
+    this.markedKatex ??= await import(/* @vite-ignore */ markedKatexSpecifier)
       .then(module => module.default)
       .catch(() => null);
 

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -265,8 +265,8 @@ export class MarkdownService {
     }
 
     // Hide the optional peer specifier from Vite import-analysis (see #681).
-    const markedKatexSpecifier = 'marked-katex-extension';
-    this.markedKatex ??= await import(/* @vite-ignore */ markedKatexSpecifier)
+    // Literal + @vite-ignore: Vite skips analysis; webpack/Karma can still resolve the peer when installed.
+    this.markedKatex ??= await import(/* @vite-ignore */ 'marked-katex-extension')
       .then(module => module.default)
       .catch(() => null);
 

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -267,7 +267,7 @@ export class MarkdownService {
     // Hide the optional peer specifier from Vite import-analysis (see #681).
     const markedKatexSpecifier = 'marked-katex-extension';
     this.markedKatex ??= await import(/* @vite-ignore */ markedKatexSpecifier)
-      .then(module => module.default)
+      .then((module: { default: MarkedKatexExtension }) => module.default)
       .catch(() => null);
 
     if (!this.markedKatex) {

--- a/lib/src/markdown.service.ts
+++ b/lib/src/markdown.service.ts
@@ -265,8 +265,8 @@ export class MarkdownService {
     }
 
     // Hide the optional peer specifier from Vite import-analysis (see #681).
-    // Literal + @vite-ignore: Vite skips analysis; webpack/Karma can still resolve the peer when installed.
-    this.markedKatex ??= await import(/* @vite-ignore */ 'marked-katex-extension')
+    const markedKatexSpecifier = 'marked-katex-extension';
+    this.markedKatex ??= await import(/* @vite-ignore */ markedKatexSpecifier)
       .then(module => module.default)
       .catch(() => null);
 

--- a/lib/src/vite-static-optional-import.spec.mjs
+++ b/lib/src/vite-static-optional-import.spec.mjs
@@ -1,0 +1,41 @@
+/**
+ * Fixture: Vite import-analysis treats a string-literal dynamic import as a
+ * static dependency. That is why unused-KaTeX apps 500 on ng serve after #660.
+ * Matches the published-path failure:
+ * Failed to resolve import "marked-katex-extension" from ngx-markdown.mjs
+ *
+ * Type-only `typeof import('...')` is erased from .mjs and is not this bug.
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const servicePath = path.join(here, 'markdown.service.ts');
+const source = fs.readFileSync(servicePath, 'utf8');
+
+// Strip type-only import() so we only see runtime dynamic imports (emitted JS).
+const withoutTypeImports = source.replace(/typeof\s+import\s*\(\s*['"][^'"]+['"]\s*\)/g, 'any');
+
+// Vite import-analysis flags import('literal'), not import(expr).
+// /* @vite-ignore */ on that statement tells Vite to skip the specifier.
+const viteStaticImport = /(?:\/\*\s*@vite-ignore\s*\*\/\s*)?import\s*\(\s*(['"])([^'"]+)\1\s*\)/g;
+
+const visible = [];
+for (const match of withoutTypeImports.matchAll(viteStaticImport)) {
+  const ignored = /@vite-ignore/.test(match[0]);
+  const specifier = match[2];
+  if (specifier === 'marked-katex-extension' && !ignored) {
+    visible.push(match[0]);
+  }
+}
+
+assert.equal(
+  visible.length,
+  0,
+  `Vite-visible static import of optional peer marked-katex-extension still present:\n${visible.join('\n')}\n` +
+    'Hide the specifier (indirect import or /* @vite-ignore */) so unused-KaTeX apps can boot.',
+);
+
+console.log('GREEN: no Vite-static runtime import("marked-katex-extension") in markdown.service.ts');


### PR DESCRIPTION
Fixes #681.

After 22.0.0 (#660) `markdown.service.ts` uses a string-literal `import('marked-katex-extension')`. Vite resolves that specifier while transforming `ngx-markdown.mjs`, so `ng serve` returns 500 when KaTeX is unused. The runtime `.catch()` never runs. `marked-katex-extension` remains an optional peer.

This hides the specifier behind a variable plus `/* @vite-ignore */` so unused-KaTeX apps boot. The three Karma specs that used to import the peer now pre-assign `markedKatex` (same pattern as the other katex tests).

Credit to @cexbrayat for the report and analysis.

## Test plan
- [ ] `node lib/src/vite-static-optional-import.spec.mjs` (fails on unmodified master; passes with this change)
- [ ] `ng serve` an Angular 22 app that uses ngx-markdown without katex / marked-katex-extension
- [ ] KaTeX still works when the optional peer is installed and `katex` is enabled